### PR TITLE
Add configurable PROJECTS_DEPTH for host daemon project scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ podman run -d --name host-daemon --network=host \
 | `HOST_TOKEN` | Token from the host registration step | *(required)* |
 | `PROJECTS_ROOT` | Root directory for project scanning | *(required)* |
 | `OTLP_PORT` | OTLP telemetry receiver port | `4318` |
+| `PROJECTS_DEPTH` | Max scan depth below `PROJECTS_ROOT` | `6` |
 | `GEMINI_API_KEY` | API key for Gemini CLI | — |
 | `CLAUDE_CODE_USE_VERTEX` | Set to `1` to use Vertex AI for Claude | — |
 | `CLOUD_ML_REGION` | GCP region (e.g., `us-east5`) | — |

--- a/agent/README.md
+++ b/agent/README.md
@@ -29,6 +29,7 @@ The daemon relies on the following environment variables:
 - `DASHBOARD_URL`: (Optional) The URL of the central Dashboard Backend. Defaults to `http://localhost:8000`.
 - `PROJECTS_ROOT`: (Optional) Root directory to scan for project repositories. Defaults to `/git`.
 - `OTLP_PORT`: (Optional) Port for the local OTLP HTTP telemetry receiver. Defaults to `4318`. Set to a different value when running multiple daemons on the same host with `Network=host`.
+- `PROJECTS_DEPTH`: (Optional) Maximum directory depth to scan for git repositories below `PROJECTS_ROOT`. Defaults to `6`.
 
 ### Tool-Specific Configuration
 

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -110,6 +110,10 @@ class HostDaemon:
         # OTLP receiver port — configurable to allow multiple
         # daemons on the same host via Network=host
         self.otlp_port = int(os.getenv("OTLP_PORT", "4318"))
+        # Maximum directory depth to scan for git repositories
+        # below PROJECTS_ROOT. Default of 6 covers most GitLab
+        # org hierarchies without being unlimited.
+        self.projects_depth = int(os.getenv("PROJECTS_DEPTH", "6"))
         self.sio = socketio.AsyncClient()
         self.agents: Dict[str, Dict] = (
             {}
@@ -236,7 +240,7 @@ class HostDaemon:
                             depth = (
                                 0 if rel_path == "." else len(rel_path.split(os.sep))
                             )
-                            if depth > 2:
+                            if depth > self.projects_depth:
                                 dirs[:] = []
                                 continue
                             if ".git" in dirs:


### PR DESCRIPTION
The project scanner in the host daemon had a hardcoded depth limit of 2, which prevented discovery of git repositories in deeply nested directory structures such as GitLab-style org hierarchies.

Add a PROJECTS_DEPTH environment variable (default 6) that controls the maximum directory depth scanned below PROJECTS_ROOT. The default of 6 covers most GitLab organization hierarchies without being unlimited, which could be slow on large filesystems.

Changes:
- agent/host_daemon.py: Read PROJECTS_DEPTH env var in __init__, replace hardcoded depth limit of 2 in _scan() with the configurable value
- agent/README.md: Document PROJECTS_DEPTH in the Configuration section
- README.md: Add PROJECTS_DEPTH to the environment variable table