### PR TITLE
Add GitLab CLI (glab) to host daemon container

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ podman run -d --name host-daemon --network=host \
   -v $HOME/.claude/:/root/.claude \
   -v $HOME/.config/gcloud:/root/.config/gcloud:ro \
   -v $HOME/.config/gh:/root/.config/gh:ro \
+  -v $HOME/.config/glab-cli:/root/.config/glab-cli:ro \
   localhost/agent-dashboard-daemon:latest
 ```
 
@@ -296,6 +297,7 @@ podman run -d --name host-daemon --network=host \
 | `CLOUD_ML_REGION` | GCP region (e.g., `us-east5`) | — |
 | `ANTHROPIC_VERTEX_PROJECT_ID` | GCP project ID for Vertex AI | — |
 | `GH_TOKEN` | GitHub CLI personal access token | — |
+| `GITLAB_TOKEN` | GitLab CLI personal access token | — |
 
 #### Volume Mounts
 
@@ -308,6 +310,7 @@ podman run -d --name host-daemon --network=host \
 | `~/.claude/` | `/root/.claude` | rw | Claude Code settings |
 | `~/.config/gcloud` | `/root/.config/gcloud` | ro | GCP credentials |
 | `~/.config/gh` | `/root/.config/gh` | ro | GitHub CLI config |
+| `~/.config/glab-cli` | `/root/.config/glab-cli` | ro | GitLab CLI config |
 
 #### GitHub CLI Authentication
 
@@ -327,6 +330,22 @@ podman run -d --name host-daemon --network=host \
 > Environment=GH_TOKEN=ghp_your-token-here    # quadlet
 > ```
 > The `GH_TOKEN` environment variable is recognized by `gh`
+> automatically and takes precedence over stored credentials.
+
+#### GitLab CLI Authentication
+
+> [!IMPORTANT]
+> The container includes the GitLab CLI (`glab`). Similar to `gh`,
+> mounting `~/.config/glab-cli` alone may not be sufficient if your
+> token is stored in the system keyring.
+>
+> Pass your token as an environment variable instead:
+> ```bash
+> # Pass it to the container
+> -e GITLAB_TOKEN="glpat_your-token-here"       # podman/docker run
+> Environment=GITLAB_TOKEN=glpat_your-token-here # quadlet
+> ```
+> The `GITLAB_TOKEN` environment variable is recognized by `glab`
 > automatically and takes precedence over stored credentials.
 
 #### Claude Code (Vertex AI)
@@ -434,6 +453,8 @@ Environment=PROJECTS_ROOT=/git
 # running multiple daemons on the same host)
 Environment=OTLP_PORT=4318
 Environment=GEMINI_API_KEY=your-key-here
+Environment=GH_TOKEN=ghp_your-token-here
+Environment=GITLAB_TOKEN=glpat_your-token-here
 Environment=CLAUDE_CODE_USE_VERTEX=1
 Environment=CLOUD_ML_REGION=us-east5
 Environment=ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
@@ -446,6 +467,7 @@ Volume=%h/.gemini/:/root/.gemini
 Volume=%h/.claude/:/root/.claude
 Volume=%h/.config/gcloud:/root/.config/gcloud:ro
 Volume=%h/.config/gh:/root/.config/gh:ro
+Volume=%h/.config/glab-cli:/root/.config/glab-cli:ro
 
 [Install]
 WantedBy=default.target

--- a/agent/Containerfile
+++ b/agent/Containerfile
@@ -33,6 +33,7 @@ RUN dnf install --setopt=install_weak_deps=False -y \
     podman \
     fuse-overlayfs \
     golang \
+    glab \
     rust \
     cargo \
     python3 \

--- a/agent/README.md
+++ b/agent/README.md
@@ -16,6 +16,7 @@ The container image bundles the following tools so spawned agents have everythin
 | **Claude Code** (`@anthropic-ai/claude-code`) | Anthropic Claude AI coding agent |
 | **Google Cloud CLI** (`gcloud`) | GCP authentication for Claude Code via Vertex AI |
 | **GitHub CLI** (`gh`) | GitHub interaction (PRs, issues, etc.) |
+| **GitLab CLI** (`glab`) | GitLab interaction (MRs, issues, etc.) |
 | **Git** | Version control |
 | **Podman** | Container builds and runtimes (podman-in-podman) |
 | **Go** (`golang`) | Go builds and tests |
@@ -38,6 +39,7 @@ Credentials and configuration for individual tools are passed into the container
 - `~/.claude` — Claude Code configuration
 - `~/.config/gcloud` — GCP credentials (for Claude Code via Vertex AI)
 - `~/.config/gh` — GitHub CLI configuration (see note below about token access)
+- `~/.config/glab-cli` — GitLab CLI configuration (see note below about token access)
 - `~/.ssh` and `~/.gitconfig` — Git/SSH configuration
 
 ### GitHub CLI Authentication in Containers
@@ -55,6 +57,19 @@ Environment=GH_TOKEN=ghp_your-token-here    # systemd quadlet
 ```
 
 `gh` recognizes `GH_TOKEN` automatically and uses it for all API calls.
+
+### GitLab CLI Authentication in Containers
+
+Similar to the GitHub CLI, `glab` may store tokens in the system keyring, making them inaccessible from inside the container.
+
+**Solution:** Pass your GitLab token via the `GITLAB_TOKEN` environment variable:
+```bash
+# Pass it to the container
+-e GITLAB_TOKEN="glpat_your-token-here"       # podman run
+Environment=GITLAB_TOKEN=glpat_your-token-here # systemd quadlet
+```
+
+`glab` recognizes `GITLAB_TOKEN` automatically and uses it for all API calls.
 
 ## Containerized Usage (Podman / Docker)
 


### PR DESCRIPTION
Add the glab package to the daemon Containerfile for GitLab interaction (merge requests, issues, pipelines, etc.) similar to how gh is included for GitHub. The package is available directly from the Fedora 42 repos so no additional repository configuration is needed.

Changes:
- agent/Containerfile: Add glab to the dnf install package list
- agent/README.md: Add GitLab CLI to the included tools table, add ~/.config/glab-cli to tool-specific config mounts, add GitLab CLI authentication section documenting GITLAB_TOKEN
- README.md: Add glab-cli volume mount to podman run example, add GITLAB_TOKEN to environment variables table, add ~/.config/glab-cli to volume mounts table, add GitLab CLI authentication note, add GH_TOKEN and GITLAB_TOKEN to the systemd quadlet example, add glab-cli volume to quadlet example