### PR TITLE
Feature/daemon container improvements

### DIFF
--- a/agent/Containerfile
+++ b/agent/Containerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # Install basic utilities, nodejs, and npm
 RUN dnf install --setopt=install_weak_deps=False -y \
     bash \
+    bash-completion \
     curl \
     nodejs \
     nodejs-full-i18n \
@@ -26,10 +27,14 @@ RUN dnf install --setopt=install_weak_deps=False -y \
     make \
     ripgrep \
     bind-utils \
+    diffstat \
+    hostname \
     strace \
     tmux \
     file \
     patch \
+    wget \
+    which \
     podman \
     fuse-overlayfs \
     golang \


### PR DESCRIPTION
  Summary         
                                                                                                                                                                            
  - Fix containers-in-containers networking by adding slirp4netns and configuring it as the default rootless network backend. This resolves the netavark: setns: Operation  
  not permitted error when running podman inside the daemon container, even with --privileged.                                                                              
  - Add general-purpose Python dev tools (black, flake8, pylint) so agents have linting and formatting available for any Python project.                                    
  - Add bash-completion to enable tab completion for git, podman, and other tools.                                                                                          
  - Add common dev utilities: diffstat, hostname, wget, which.   