### PR TITLE
Filter DA terminal response from input to fix Gemini 1;2c bug

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -433,12 +433,23 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
       },
     );
 
+    // Filter terminal responses (like DA — Device Attributes)
+    // from user input before relaying to the daemon. xterm.js
+    // responds to DA queries (ESC [ c) from the remote process
+    // with ESC [ ? ... c, which flows back through onData.
+    // Some CLIs (Gemini) capture this response as stdin input,
+    // showing "1;2c" in the prompt.
+    // eslint-disable-next-line no-control-regex
+    const DA_RESPONSE = /\x1b\[\?[\d;]*c/;
     term.onData((data) => {
       if (!isReplaying.current) {
-        socket.emit('terminal_input', {
-          target_sid: agentId,
-          input: data,
-        });
+        const filtered = data.replace(DA_RESPONSE, '');
+        if (filtered) {
+          socket.emit('terminal_input', {
+            target_sid: agentId,
+            input: filtered,
+          });
+        }
       }
     });
 


### PR DESCRIPTION
When xterm.js receives a Device Attributes (DA) query from the remote process (ESC [ c), it responds with its terminal identification (ESC [ ? 1 ; 2 c). This response flows back through term.onData and gets relayed to the daemon as terminal input. Most CLIs ignore this, but Gemini CLI captures it as stdin input, displaying "1;2c" in the prompt on every session start or re-attach.

Fix by filtering DA responses (ESC [ ? ... c pattern) from the onData handler before sending to the daemon socket. The filtered response is silently dropped since no CLI needs to receive its own DA query response as user input.

Closes #21