### PR TITLE
Add git worktree isolation for concurrent agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,13 @@ session cost.
   from the dropdown when spawning an agent.
 - **Session resume** — Agents can resume their latest session on
   spawn, preserving conversation context across daemon restarts.
+- **Git worktree isolation** — Optionally spawn agents in
+  isolated git worktrees so multiple agents can work on the
+  same repository without conflicts. Smart defaults enable
+  isolation when another agent is already active on the project.
 - **Companion sessions** — Open a Bash shell alongside a Claude
-  or Gemini session in the same project directory.
+  or Gemini session in the same project directory. Companions
+  inherit the parent's working context (worktree or original).
 - **Host management** — Register, monitor, and delete hosts with
   cascading cleanup of associated sessions.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ session cost.
 The following projects offer alternative approaches to AI agent orchestration:
 
 - **Agent Dashboard** (This project)
-  - A web-based platform that provides multi-host orchestration and remote pseudo-terminal (PTY) access to AI agent sessions with live OpenTelemetry metrics.
+  - A web-based platform that provides multi-host orchestration and remote pseudo-terminal (PTY) access to AI agent sessions with live OpenTelemetry metrics. Supports optional git worktree isolation for running multiple agents on the same repository, real-time cost tracking, and companion session chaining.
   - **Ideal for:** Remote, web-based interaction with isolated AI agent sessions across multiple host machines via full PTY emulation.
   - **Not ideal for:** Users who prefer to work exclusively within a local, native terminal multiplexer.
   - **Restrictions:** Designed specifically to orchestrate supported CLI agents (currently Gemini CLI, Claude Code, and Bash) rather than general-purpose GUI agents or arbitrary scripts.

--- a/agent/README.md
+++ b/agent/README.md
@@ -114,5 +114,19 @@ The daemon maintains the following telemetry fields for each agent, broadcast to
 | `mcp_servers` | Config files | MCP server names detected from `.mcp.json`, `~/.claude.json`, or `~/.gemini/settings.json` |
 | `last_cmd` | PROMPT_COMMAND (bash only) | Last executed command text, extracted from bash history |
 | `last_exit_code` | PROMPT_COMMAND (bash only) | Exit code of the last command. Non-zero values trigger an error badge on the card. |
+| `worktree_path` | Daemon (spawn) | Absolute path to the git worktree directory, if the agent was spawned with worktree isolation. Null otherwise. |
 | `git_branch` | Git | Current branch of the agent's working directory |
 | `git_project` | Git | Repository name extracted from the git remote URL |
+
+### Git Worktree Isolation
+
+When spawning an agent, the user can enable "Worktree Isolation" to create a separate git worktree for the session. This prevents concurrent agents from conflicting on the same working tree.
+
+**Lifecycle:**
+1. **Creation**: The daemon creates a worktree at `{PROJECTS_ROOT}/.agent-worktrees/{project}/agent-{id[:8]}` with a new branch `agent/{tool}-{id[:8]}` based on the current HEAD.
+2. **Working directory**: The agent process runs in the worktree directory instead of the original project.
+3. **Cleanup**: When the agent is stopped or closed, the daemon removes the worktree (`git worktree remove --force`) and deletes the branch (`git branch -D`).
+
+**Companion sessions** inherit the parent agent's working directory (worktree or original) and do not create additional worktrees. This ensures companion chains (e.g. Claude → Bash → Gemini) all share the same working context.
+
+**Smart default**: The spawn modal defaults the worktree toggle to ON when another agent is already active on the same project and host.

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -175,6 +175,7 @@ class HostDaemon:
             project_dir = data.get("project_dir")
             task_description = data.get("task_description")
             session_mode = data.get("session_mode", "resume")
+            use_worktree = data.get("use_worktree", False)
             cols = data.get("cols", 120)
             rows = data.get("rows", 40)
             await self.spawn_agent(
@@ -183,6 +184,7 @@ class HostDaemon:
                 project_dir,
                 task_description,
                 session_mode,
+                use_worktree,
                 cols,
                 rows,
             )
@@ -401,6 +403,7 @@ class HostDaemon:
         project_dir: Optional[str] = None,
         task: Optional[str] = None,
         session_mode: str = "resume",
+        use_worktree: bool = False,
         cols: int = 120,
         rows: int = 40,
     ):
@@ -413,6 +416,9 @@ class HostDaemon:
             task: Optional task description for the session.
             session_mode: 'resume' to continue the latest session
                           (default), or 'new' for a fresh session.
+            use_worktree: If True, create a git worktree for
+                          isolation from other agents on the same
+                          repo.
             cols: Initial terminal width in columns (default 120).
             rows: Initial terminal height in rows (default 40).
         """
@@ -425,15 +431,71 @@ class HostDaemon:
         if full_path:
             full_path = os.path.abspath(full_path)
 
+        # Create a git worktree for isolation if requested.
+        # The worktree is stored under PROJECTS_ROOT/.agent-worktrees/
+        # to keep the original repo clean.  MCP detection and
+        # companion matching use the original project_dir.
+        original_project_dir = full_path
+        worktree_path = None
+        worktree_branch = None
+        if use_worktree and full_path:
+            try:
+                project_name = os.path.relpath(full_path, self.projects_root)
+                short_id = agent_id[:8]
+                worktree_dir = os.path.join(
+                    self.projects_root,
+                    ".agent-worktrees",
+                    project_name,
+                    f"agent-{short_id}",
+                )
+                worktree_branch = f"agent/{tool}-{short_id}"
+                os.makedirs(os.path.dirname(worktree_dir), exist_ok=True)
+                # Prune stale worktree refs before creating
+                subprocess.run(
+                    ["git", "worktree", "prune"],
+                    cwd=full_path,
+                    capture_output=True,
+                    check=False,
+                )
+                subprocess.check_output(
+                    [
+                        "git",
+                        "worktree",
+                        "add",
+                        "-b",
+                        worktree_branch,
+                        worktree_dir,
+                    ],
+                    cwd=full_path,
+                    stderr=subprocess.STDOUT,
+                )
+                worktree_path = worktree_dir
+                full_path = worktree_dir
+                # Worktrees have no prior session state
+                session_mode = "new"
+                print(
+                    f"Created worktree for {agent_id}: "
+                    f"{worktree_dir} (branch {worktree_branch})"
+                )
+            except Exception as e:
+                print(
+                    f"Failed to create worktree for "
+                    f"{agent_id}: {e}. "
+                    f"Falling back to original directory."
+                )
+                full_path = original_project_dir
+                worktree_path = None
+                worktree_branch = None
+
         print(
             f"Spawning agent {agent_id} with tool: {tool} "
             f"mode: {session_mode} in {full_path}"
         )
 
         branch, project = self.get_git_info(full_path)
-        mcp_servers = self._detect_mcp_servers(full_path, tool)
+        mcp_servers = self._detect_mcp_servers(original_project_dir, tool)
         telemetry = {
-            "project_dir": full_path,
+            "project_dir": original_project_dir,
             "task_description": task,
             "git_branch": branch,
             "git_project": project,
@@ -449,6 +511,7 @@ class HostDaemon:
             "agent_status": "idle",
             "mcp_servers": mcp_servers,
             "run_time_seconds": 0,
+            "worktree_path": worktree_path,
         }
 
         # Build command based on session_mode.
@@ -550,6 +613,9 @@ class HostDaemon:
                 "permission_waiting": False,
                 "permission_candidate": 0,
                 "utf8_buffer": b"",
+                "worktree_path": worktree_path,
+                "worktree_branch": worktree_branch,
+                "original_project_dir": original_project_dir,
             }
             if self.sio.connected:
                 await self.sio.emit(

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -733,6 +733,38 @@ class HostDaemon:
                 os.unlink(sidecar)
             except OSError:
                 pass
+            # Clean up git worktree if one was created
+            wt_path = self.agents[agent_id].get("worktree_path")
+            wt_branch = self.agents[agent_id].get("worktree_branch")
+            orig_dir = self.agents[agent_id].get("original_project_dir")
+            if wt_path and orig_dir:
+                try:
+                    subprocess.run(
+                        ["git", "worktree", "remove", "--force", wt_path],
+                        cwd=orig_dir,
+                        capture_output=True,
+                        check=False,
+                    )
+                    print(f"Removed worktree {wt_path}")
+                except Exception as e:
+                    print(f"Failed to remove worktree {wt_path}: {e}")
+                if wt_branch:
+                    try:
+                        subprocess.run(
+                            ["git", "branch", "-D", wt_branch],
+                            cwd=orig_dir,
+                            capture_output=True,
+                            check=False,
+                        )
+                    except Exception as e:
+                        print(f"Failed to delete branch {wt_branch}: {e}")
+                # Clean up empty parent directories
+                try:
+                    parent = os.path.dirname(wt_path)
+                    if os.path.isdir(parent) and not os.listdir(parent):
+                        os.rmdir(parent)
+                except OSError:
+                    pass
             del self.agents[agent_id]
             if self.sio.connected:
                 asyncio.create_task(

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -487,6 +487,34 @@ class HostDaemon:
                 worktree_path = None
                 worktree_branch = None
 
+        # Detect if full_path is inside an existing worktree
+        # (e.g. companion session spawned into a parent's
+        # worktree). Set worktree_path so the UI shows the
+        # worktree indicator, and resolve the original
+        # project_dir for MCP detection and companion matching.
+        worktree_marker = os.path.join(self.projects_root, ".agent-worktrees")
+        if not worktree_path and full_path and full_path.startswith(worktree_marker):
+            worktree_path = full_path
+            # Resolve original project_dir from the worktree's
+            # git configuration.
+            try:
+                git_common = (
+                    subprocess.check_output(
+                        ["git", "rev-parse", "--git-common-dir"],
+                        cwd=full_path,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    .decode()
+                    .strip()
+                )
+                # git-common-dir returns the .git dir of the
+                # parent repo (e.g. /git/project/.git)
+                if git_common and not git_common.startswith("/"):
+                    git_common = os.path.normpath(os.path.join(full_path, git_common))
+                original_project_dir = os.path.dirname(git_common)
+            except Exception:
+                pass
+
         print(
             f"Spawning agent {agent_id} with tool: {tool} "
             f"mode: {session_mode} in {full_path}"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -295,30 +295,50 @@ def get_agent_companions(
     user: dict = Depends(auth.get_current_user),
 ):
     """
-    Returns active companion agents on the same host with the same
-    project_dir. A companion is any other active agent sharing the
-    same host_id and project_dir (extracted from telemetry_json).
+    Returns active companion agents on the same host sharing
+    the same effective working directory. Companions are matched
+    by worktree_path when present (agents sharing the same
+    worktree), or by project_dir when neither agent has a
+    worktree (agents sharing the original repo). This prevents
+    worktree-isolated agents from being matched as companions
+    to non-worktree agents on the same project.
     Requires UI login.
     """
     db_agent = db.query(models.Agent).filter(models.Agent.agent_id == agent_id).first()
     if not db_agent:
         raise HTTPException(status_code=404, detail="Agent not found.")
 
-    project_dir = (db_agent.telemetry_json or {}).get("project_dir")
+    tel = db_agent.telemetry_json or {}
+    worktree_path = tel.get("worktree_path")
+    project_dir = tel.get("project_dir")
     if not project_dir:
         return []
 
-    companions = (
-        db.query(models.Agent)
-        .filter(
-            models.Agent.host_id == db_agent.host_id,
-            models.Agent.status == "active",
-            models.Agent.agent_id != agent_id,
-            func.json_extract(models.Agent.telemetry_json, "$.project_dir")
-            == project_dir,
+    # Match companions by effective working directory:
+    # if this agent is in a worktree, find others in the
+    # same worktree. If not, find others also without a
+    # worktree on the same project.
+    base_filter = [
+        models.Agent.host_id == db_agent.host_id,
+        models.Agent.status == "active",
+        models.Agent.agent_id != agent_id,
+    ]
+    if worktree_path:
+        base_filter.append(
+            func.json_extract(models.Agent.telemetry_json, "$.worktree_path")
+            == worktree_path
         )
-        .all()
-    )
+    else:
+        base_filter.append(
+            func.json_extract(models.Agent.telemetry_json, "$.project_dir")
+            == project_dir
+        )
+        # Exclude agents that have a worktree_path set
+        base_filter.append(
+            func.json_extract(models.Agent.telemetry_json, "$.worktree_path").is_(None)
+        )
+
+    companions = db.query(models.Agent).filter(*base_filter).all()
     return companions
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -128,6 +128,7 @@ class SpawnRequest(BaseModel):
     project_dir: Optional[str] = None
     task_description: Optional[str] = None
     session_mode: Optional[str] = "resume"
+    use_worktree: Optional[bool] = False
     cols: Optional[int] = 120
     rows: Optional[int] = 40
 
@@ -351,6 +352,7 @@ async def spawn_agent(
         telemetry_json={
             "project_dir": request.project_dir,
             "task_description": request.task_description,
+            "use_worktree": request.use_worktree or False,
         },
     )
     db.add(db_agent)
@@ -367,6 +369,7 @@ async def spawn_agent(
             "project_dir": request.project_dir,
             "task_description": request.task_description,
             "session_mode": request.session_mode or "resume",
+            "use_worktree": request.use_worktree or False,
             "cols": request.cols or 120,
             "rows": request.rows or 40,
         },

--- a/frontend/Containerfile
+++ b/frontend/Containerfile
@@ -22,8 +22,14 @@ FROM registry.fedoraproject.org/fedora-minimal:42
 # Install nginx
 RUN microdnf install -y nginx && microdnf clean all
 
-# Remove default nginx configs to avoid conflicts
-RUN rm -f /etc/nginx/conf.d/default.conf /etc/nginx/nginx.conf.default
+# Remove default nginx configs and the default server block
+# in the main nginx.conf to avoid conflicts with our config.
+# Fedora's nginx.conf includes a catch-all server on :80
+# before conf.d/ is loaded, which would 404 on client-side
+# routes like /terminal/{id}.
+RUN rm -f /etc/nginx/conf.d/default.conf \
+         /etc/nginx/nginx.conf.default \
+    && sed -i '/^    server {/,/^    }/d' /etc/nginx/nginx.conf
 
 # Copy custom NGINX configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -47,6 +47,7 @@ export interface Agent {
     mcp_servers?: string[];
     last_exit_code?: number;
     last_cmd?: string;
+    worktree_path?: string;
   };
 }
 
@@ -70,6 +71,7 @@ export const spawnAgent = async (
   projectDir?: string,
   taskDescription?: string,
   sessionMode?: string,
+  useWorktree?: boolean,
   cols?: number,
   rows?: number,
 ): Promise<Agent> => {
@@ -79,6 +81,7 @@ export const spawnAgent = async (
     project_dir: projectDir,
     task_description: taskDescription,
     session_mode: sessionMode || 'resume',
+    use_worktree: useWorktree || false,
     cols: cols || 120,
     rows: rows || 40,
   });

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -49,6 +49,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
     projectDir?: string,
     taskDescription?: string,
     sessionMode?: string,
+    useWorktree?: boolean,
   ) => {
     try {
       const newAgent = await spawnAgent(
@@ -57,6 +58,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
         projectDir,
         taskDescription,
         sessionMode,
+        useWorktree,
       );
       setActiveSpawn(null);
       await fetchData();
@@ -264,14 +266,18 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
         <SpawnModal
           host={hosts.find((h) => h.id === activeSpawn.hostId)!}
           tool={activeSpawn.tool}
+          activeAgents={activeAgents.filter(
+            (a) => a.host_id === activeSpawn.hostId,
+          )}
           onClose={() => setActiveSpawn(null)}
-          onSpawn={(dir, task, sessionMode) =>
+          onSpawn={(dir, task, sessionMode, useWorktree) =>
             handleSpawn(
               activeSpawn.hostId,
               activeSpawn.tool,
               dir,
               task,
               sessionMode,
+              useWorktree,
             )
           }
           onRefresh={requestProjects}

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -5,6 +5,7 @@ import { io, Socket } from 'socket.io-client';
 import {
   XCircle,
   GitBranch,
+  GitFork,
   Monitor,
   TerminalSquare,
   ExternalLink,
@@ -482,6 +483,7 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
   const hostName = agentDetail?.host_name;
   const gitProject = agentDetail?.telemetry?.git_project;
   const gitBranch = agentDetail?.telemetry?.git_branch;
+  const worktreePath = agentDetail?.telemetry?.worktree_path;
 
   // Update browser window title with host / project / branch
   useEffect(() => {
@@ -489,11 +491,12 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
     if (hostName) parts.push(hostName);
     if (gitProject) parts.push(gitProject);
     if (gitBranch) parts.push(gitBranch);
+    if (worktreePath) parts.push('worktree');
     document.title = parts.join(' · ');
     return () => {
       document.title = 'Agent Dashboard';
     };
-  }, [category, hostName, gitProject, gitBranch]);
+  }, [category, hostName, gitProject, gitBranch, worktreePath]);
 
   // Build companion buttons based on current tool type
   const companionButtons: { label: string; tool: ToolCategory }[] = [];
@@ -538,6 +541,12 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
                   className="text-emerald-400 shrink-0 ml-1"
                 />
                 <span className="text-emerald-300">{gitBranch}</span>
+              </>
+            )}
+            {worktreePath && (
+              <>
+                <GitFork size={12} className="text-amber-400 shrink-0 ml-1" />
+                <span className="text-amber-300">worktree</span>
               </>
             )}
           </div>

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -111,11 +111,18 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
         await stopAgent(agentId).catch(() => {});
 
         // Spawn a new agent with the same parameters,
-        // using resume mode for session continuity
+        // using resume mode for session continuity.
+        // If the stale session was in a worktree, use
+        // the worktree path so the agent resumes in the
+        // same isolated directory with its branch and
+        // uncommitted work intact.
+        const projectDir =
+          agentDetail.telemetry?.worktree_path ||
+          agentDetail.telemetry?.project_dir;
         const newAgent = await spawnAgent(
           agentDetail.host_id,
           agentDetail.tool_name || 'gemini',
-          agentDetail.telemetry?.project_dir,
+          projectDir,
           agentDetail.telemetry?.task_description,
           'resume',
         );

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -170,11 +170,19 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
       if (!agentDetail || spawning) return;
       setSpawning(true);
       try {
-        const projectDir = agentDetail.telemetry?.project_dir;
+        // Use the worktree path if present so the
+        // companion inherits the same working directory
+        // as the parent agent (worktree or original).
+        const projectDir =
+          agentDetail.telemetry?.worktree_path ||
+          agentDetail.telemetry?.project_dir;
         const spawned = await spawnAgent(
           agentDetail.host_id,
           targetTool,
           projectDir,
+          undefined, // taskDescription
+          undefined, // sessionMode
+          false, // useWorktree — share parent's directory
         );
         openTerminalWindow(spawned.agent_id);
       } catch (err) {

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -8,6 +8,7 @@ import {
   Clock,
   FolderOpen,
   ChevronRight,
+  GitFork,
 } from 'lucide-react';
 import type { Agent } from '../../api';
 import {
@@ -89,6 +90,14 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
             {tel.git_branch && (
               <span className="flex items-center gap-1.5 text-[10px] text-slate-400 font-mono">
                 <GitBranch size={10} /> {tel.git_branch}
+              </span>
+            )}
+            {tel.worktree_path && (
+              <span
+                className="flex items-center gap-1 text-[10px] text-amber-400/70 font-mono"
+                title={`Worktree: ${tel.worktree_path}`}
+              >
+                <GitFork size={10} /> worktree
               </span>
             )}
             {(tel.run_time_seconds || agent.started_at) && (

--- a/frontend/src/components/dashboard/SpawnModal.tsx
+++ b/frontend/src/components/dashboard/SpawnModal.tsx
@@ -1,24 +1,41 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { PlusCircle, X, ChevronRight, RefreshCw, Folder } from 'lucide-react';
-import type { Host } from '../../api';
+import {
+  PlusCircle,
+  X,
+  ChevronRight,
+  RefreshCw,
+  Folder,
+  GitFork,
+} from 'lucide-react';
+import type { Agent, Host } from '../../api';
 
 /** Props for the SpawnModal component. */
 export interface SpawnModalProps {
   host: Host;
   tool: string;
+  /** Active agents on this host, used to compute the
+   *  smart default for the worktree isolation toggle. */
+  activeAgents?: Agent[];
   onClose: () => void;
-  onSpawn: (dir: string, task: string, sessionMode: string) => void;
+  onSpawn: (
+    dir: string,
+    task: string,
+    sessionMode: string,
+    useWorktree: boolean,
+  ) => void;
   onRefresh: () => void;
 }
 
 /**
  * Modal dialog for spawning a new agent session on a host.
  * Allows selecting a project directory, entering a task
- * description, and choosing resume vs. new session mode.
+ * description, choosing resume vs. new session mode, and
+ * optionally isolating the session in a git worktree.
  */
 const SpawnModal: React.FC<SpawnModalProps> = ({
   host,
   tool,
+  activeAgents = [],
   onClose,
   onSpawn,
   onRefresh,
@@ -30,6 +47,7 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
   const [selectedProject, setSelectedProject] = useState('');
   const [task, setTask] = useState('');
   const [resumeSession, setResumeSession] = useState(true);
+  const [useWorktree, setUseWorktree] = useState(false);
   const showResume = tool === 'claude' || tool === 'gemini';
 
   // Auto-select first project when list arrives
@@ -39,6 +57,25 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
       setSelectedProject(projects[0]);
     }
   }, [projects, selectedProject]);
+
+  // Smart default: enable worktree isolation when another
+  // agent is already active on the selected project.
+  // Uses the original project_dir for matching so
+  // worktree-isolated agents are counted too.
+  useEffect(() => {
+    if (!selectedProject) return;
+    const projectsRoot = host.projects?.projects_root || '/git';
+    const fullPath = `${projectsRoot}/${selectedProject}`;
+    const hasActiveAgent = activeAgents.some(
+      (a) => a.telemetry?.project_dir === fullPath,
+    );
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- derive from props
+    setUseWorktree(hasActiveAgent);
+  }, [selectedProject, activeAgents, host.projects?.projects_root]);
+
+  // When worktree is enabled, force session mode to "new"
+  // since the worktree has no prior session state.
+  const effectiveResume = useWorktree ? false : resumeSession;
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4">
@@ -116,35 +153,70 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
           </div>
 
           {showResume && (
-            <div className="flex items-center justify-between">
+            <div
+              className={`flex items-center justify-between ${useWorktree ? 'opacity-50' : ''}`}
+            >
               <div>
                 <label className="block text-xs font-bold text-slate-400 uppercase tracking-widest">
                   Session Mode
                 </label>
                 <p className="text-[10px] text-slate-500 mt-0.5">
-                  {resumeSession
-                    ? 'Continue the most recent session in this project'
-                    : 'Start a fresh session'}
+                  {useWorktree
+                    ? 'New session (required for worktree isolation)'
+                    : effectiveResume
+                      ? 'Continue the most recent session in this project'
+                      : 'Start a fresh session'}
                 </p>
               </div>
               <button
                 type="button"
                 onClick={() => setResumeSession(!resumeSession)}
+                disabled={useWorktree}
                 className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                  resumeSession ? 'bg-accent' : 'bg-slate-600'
-                }`}
+                  effectiveResume ? 'bg-accent' : 'bg-slate-600'
+                } ${useWorktree ? 'cursor-not-allowed' : ''}`}
               >
                 <span
                   className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
-                    resumeSession ? 'translate-x-6' : 'translate-x-1'
+                    effectiveResume ? 'translate-x-6' : 'translate-x-1'
                   }`}
                 />
               </button>
               <span className="text-xs text-slate-300 font-medium ml-2 w-16">
-                {resumeSession ? 'Resume' : 'New'}
+                {effectiveResume ? 'Resume' : 'New'}
               </span>
             </div>
           )}
+
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="block text-xs font-bold text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
+                <GitFork size={12} />
+                Worktree Isolation
+              </label>
+              <p className="text-[10px] text-slate-500 mt-0.5">
+                {useWorktree
+                  ? 'Create a separate working copy for this agent'
+                  : 'Agent works directly in the project directory'}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setUseWorktree(!useWorktree)}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                useWorktree ? 'bg-accent' : 'bg-slate-600'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                  useWorktree ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+            <span className="text-xs text-slate-300 font-medium ml-2 w-16">
+              {useWorktree ? 'Isolated' : 'Shared'}
+            </span>
+          </div>
 
           <div>
             <label className="block text-xs font-bold text-slate-400 uppercase tracking-widest mb-2">
@@ -168,7 +240,12 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
           </button>
           <button
             onClick={() =>
-              onSpawn(selectedProject, task, resumeSession ? 'resume' : 'new')
+              onSpawn(
+                selectedProject,
+                task,
+                effectiveResume ? 'resume' : 'new',
+                useWorktree,
+              )
             }
             disabled={!selectedProject}
             className={`flex-1 font-bold py-2.5 rounded-xl transition-all shadow-lg active:scale-95 flex items-center justify-center gap-2 ${


### PR DESCRIPTION
  ## Summary                                                                                                                                        
                                                                                                                                                    
  - **Git worktree isolation** — New "Isolate in worktree" toggle in the spawn modal creates a separate git worktree for the agent session, preventing concurrent agents from conflicting on the same working tree. Worktrees are stored under `{PROJECTS_ROOT}/.agent-worktrees/` with auto-generated branches (`agent/{tool}-{id[:8]}`). Cleaned up automatically on agent stop/close.                                                  
  - **Smart default** — The toggle defaults ON when another agent is already active on the same project and host, OFF otherwise.
  - **Companion inheritance** — Companion sessions (Claude → Bash → Gemini chains) inherit the parent's working directory (worktree or original) without creating additional worktrees.                                                                                                            
  - **Visual indicators** — Worktree-isolated agents show a GitFork icon with "worktree" label (amber) on both the dashboard card and the terminal popup header. Window titles include "worktree" for easy identification.                                                                           
  - **Nginx fix** — Remove Fedora's default server block from nginx.conf during container build, fixing 404 errors on client-side routes like `/terminal/{id}` caused by a base image update.                                                                                                   
                                                            
  ## Changes                                                                                                                                        
                                                            
  | File | What |                                                                                                                                   
  |------|------|                                           
  | `backend/app/main.py` | Add `use_worktree` to SpawnRequest and Socket.IO relay |                                                                
  | `frontend/src/api.ts` | Add `useWorktree` param and `worktree_path` telemetry field |                                                           
  | `agent/host_daemon.py` | Worktree creation in `spawn_agent()`, cleanup in `close_agent()`, companion directory inheritance |                    
  | `frontend/src/components/dashboard/SpawnModal.tsx` | Worktree toggle with smart default, session mode interaction |                             
  | `frontend/src/components/Dashboard.tsx` | Pass activeAgents to SpawnModal, forward useWorktree |                                                
  | `frontend/src/components/Terminal.tsx` | Companion worktree inheritance, header/title indicators |                                              
  | `frontend/src/components/dashboard/AgentSessionCard.tsx` | Worktree badge on cards |                                                            
  | `frontend/Containerfile` | Fix nginx default server block conflict |                                                                            
  | `agent/README.md` | Document worktree lifecycle, telemetry field, companion behavior |                                                          
  | `README.md` | Add worktree isolation to features and Similar Tools description |                                                                
                                                                                                                                                    
  ## Test plan                                                                                                                                      
                                                                                                                                                    
  - [x] Spawn agent without worktree → works as before, no indicator                                                                                
  - [x] Spawn second agent on same project → toggle defaults ON
  - [x] Enable worktree → agent spawns in `.agent-worktrees/`, session mode forced to "new"                                                         
  - [x] Card shows GitFork icon + "worktree" label in amber                                                                                         
  - [x] Terminal popup header shows worktree indicator, window title includes "worktree"                                                            
  - [x] Spawn companion from worktree-isolated agent → companion shares worktree directory                                                          
  - [x] Stop worktree agent → worktree directory and branch cleaned up (`git worktree list` confirms)                                               
  - [x] `/terminal/{id}` routes work (no nginx 404)                                                                                                 
  - [x] All precommit checks pass                                                                                                                   
  - [x] All 45 daemon unit tests pass                                                                                                               
                                                                                                                                                    
  Closes #26   