### PR TITLE
Fix Gemini status chip stuck on WORKING

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1025,7 +1025,6 @@ class HostDaemon:
                 if not agent_id:
                     print(f"OTLP: no agent match for resource " f"attrs: {res_attrs}")
                     continue
-                self.agents[agent_id]["last_otlp_time"] = time.monotonic()
                 tel = self.agents[agent_id]["telemetry"]
                 changed = False
 
@@ -1037,12 +1036,14 @@ class HostDaemon:
                         if self._update_telemetry_from_attrs(tel, attrs):
                             changed = True
 
-                if changed and self.sio.connected:
-                    await self.sio.emit(
-                        "agent_telemetry",
-                        {"agent_id": agent_id, "telemetry": tel},
-                        namespace="/terminal",
-                    )
+                if changed:
+                    self.agents[agent_id]["last_otlp_time"] = time.monotonic()
+                    if self.sio.connected:
+                        await self.sio.emit(
+                            "agent_telemetry",
+                            {"agent_id": agent_id, "telemetry": tel},
+                            namespace="/terminal",
+                        )
 
             # Process OTLP Traces (resourceSpans → scopeSpans → spans)
             for res_span in data.get("resourceSpans", []):
@@ -1054,7 +1055,6 @@ class HostDaemon:
 
                 if not agent_id:
                     continue
-                self.agents[agent_id]["last_otlp_time"] = time.monotonic()
                 tel = self.agents[agent_id]["telemetry"]
                 changed = False
 
@@ -1094,12 +1094,14 @@ class HostDaemon:
                                 info["permission_candidate"] = time.monotonic()
                                 changed = True
 
-                if changed and self.sio.connected:
-                    await self.sio.emit(
-                        "agent_telemetry",
-                        {"agent_id": agent_id, "telemetry": tel},
-                        namespace="/terminal",
-                    )
+                if changed:
+                    self.agents[agent_id]["last_otlp_time"] = time.monotonic()
+                    if self.sio.connected:
+                        await self.sio.emit(
+                            "agent_telemetry",
+                            {"agent_id": agent_id, "telemetry": tel},
+                            namespace="/terminal",
+                        )
 
             # Process OTLP Metrics
             # (resourceMetrics → scopeMetrics → metrics → dataPoints)
@@ -1114,7 +1116,6 @@ class HostDaemon:
 
                 if not agent_id:
                     continue
-                self.agents[agent_id]["last_otlp_time"] = time.monotonic()
                 tel = self.agents[agent_id]["telemetry"]
                 changed = False
 
@@ -1253,12 +1254,14 @@ class HostDaemon:
                                     tel["run_time_seconds"] = int(value / 1000)
                                     changed = True
 
-                if changed and self.sio.connected:
-                    await self.sio.emit(
-                        "agent_telemetry",
-                        {"agent_id": agent_id, "telemetry": tel},
-                        namespace="/terminal",
-                    )
+                if changed:
+                    self.agents[agent_id]["last_otlp_time"] = time.monotonic()
+                    if self.sio.connected:
+                        await self.sio.emit(
+                            "agent_telemetry",
+                            {"agent_id": agent_id, "telemetry": tel},
+                            namespace="/terminal",
+                        )
 
             return web.Response(status=200)
         except Exception as e:


### PR DESCRIPTION
## Summary

- Fix the Gemini agent status chip never transitioning from "Working" to "Idle" by only updating `last_otlp_time` when telemetry values actually change. Previously, every OTLP payload (including unchanged cumulative counters) reset the activity timer, keeping the status permanently stuck on "Working".

## Test plan

- [ ] Spawn a Gemini session, interact with it, then let it sit idle
- [ ] Status chip transitions to "Idle" after ~15 seconds of no activity
- [ ] Claude sessions still transition correctly between Working/Idle
- [ ] All daemon unit tests pass

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)