### PR TITLE
Update model context windows and pricing to match published specs

### DIFF
--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -127,11 +127,9 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
               {tel.model || '...'}
             </p>
             {tel.model && !isModelRecognized(tel.model) && (
-              <TriangleAlert
-                size={12}
-                className="text-amber-400 shrink-0"
-                title="Unrecognized model — context window and pricing may be inaccurate"
-              />
+              <span title="Unrecognized model — context window and pricing may be inaccurate">
+                <TriangleAlert size={12} className="text-amber-400 shrink-0" />
+              </span>
             )}
           </div>
           <div className="mt-1.5">

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -9,6 +9,7 @@ import {
   FolderOpen,
   ChevronRight,
   GitFork,
+  TriangleAlert,
 } from 'lucide-react';
 import type { Agent } from '../../api';
 import {
@@ -19,6 +20,7 @@ import {
   estimateCost,
   formatCost,
   formatTokenCount,
+  isModelRecognized,
 } from './utils';
 import StatusIndicator from './StatusIndicator';
 import EditableTaskDescription from './EditableTaskDescription';
@@ -120,9 +122,18 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
 
       {agent.tool_name !== 'bash' && (
         <div className="my-2 border-t border-slate-700/50 pt-2">
-          <p className="text-[11px] text-slate-300 font-mono truncate">
-            {tel.model || '...'}
-          </p>
+          <div className="flex items-center gap-1">
+            <p className="text-[11px] text-slate-300 font-mono truncate">
+              {tel.model || '...'}
+            </p>
+            {tel.model && !isModelRecognized(tel.model) && (
+              <TriangleAlert
+                size={12}
+                className="text-amber-400 shrink-0"
+                title="Unrecognized model — context window and pricing may be inaccurate"
+              />
+            )}
+          </div>
           <div className="mt-1.5">
             <div className="flex justify-between items-center mb-1">
               <span className="text-[9px] text-slate-500 uppercase font-bold tracking-tight">

--- a/frontend/src/components/dashboard/__tests__/utils.test.ts
+++ b/frontend/src/components/dashboard/__tests__/utils.test.ts
@@ -24,16 +24,36 @@ describe('getContextWindow', () => {
     expect(getContextWindow('claude-3-5-sonnet')).toBe(200000);
   });
 
-  it('returns 1M for claude-opus-4 model', () => {
-    expect(getContextWindow('claude-opus-4-20250514')).toBe(1000000);
+  it('returns 200k for claude-opus-4 (deprecated)', () => {
+    expect(getContextWindow('claude-opus-4-20250514')).toBe(200000);
   });
 
-  it('returns 2M for gemini-2.5-pro model', () => {
-    expect(getContextWindow('gemini-2.5-pro-latest')).toBe(2000000);
+  it('returns 200k for claude-opus-4-6 without suffix', () => {
+    expect(getContextWindow('claude-opus-4-6')).toBe(200000);
   });
 
-  it('falls back to 1M for unknown gemini model', () => {
-    expect(getContextWindow('gemini-99-turbo')).toBe(1000000);
+  it('returns 200k for claude-haiku-4', () => {
+    expect(getContextWindow('claude-haiku-4-5')).toBe(200000);
+  });
+
+  it('returns 1M when model has [1m] suffix', () => {
+    expect(getContextWindow('claude-opus-4-6[1m]')).toBe(1000000);
+  });
+
+  it('returns 1M for sonnet with [1m] suffix', () => {
+    expect(getContextWindow('claude-sonnet-4-6[1m]')).toBe(1000000);
+  });
+
+  it('returns 1048576 for gemini-2.5-pro model', () => {
+    expect(getContextWindow('gemini-2.5-pro-latest')).toBe(1048576);
+  });
+
+  it('returns 1048576 for gemini-2.5-flash-lite', () => {
+    expect(getContextWindow('gemini-2.5-flash-lite')).toBe(1048576);
+  });
+
+  it('falls back to 1048576 for unknown gemini model', () => {
+    expect(getContextWindow('gemini-99-turbo')).toBe(1048576);
   });
 
   it('falls back to 200k for unknown claude model', () => {
@@ -41,15 +61,15 @@ describe('getContextWindow', () => {
   });
 
   it('expands beyond limit when tokens exceed base', () => {
-    // claude-3-5 base is 200k; if usage is 250k, should expand
+    // claude-3-5 base is 200k; if usage is 250k, expand
     const result = getContextWindow('claude-3-5-sonnet', 250000);
     expect(result).toBeGreaterThan(250000);
   });
 
   it('contracts on very low usage', () => {
-    // gemini-2.5-pro base is 2M; usage of 10k should contract
+    // gemini-2.5-pro base is 1048576; usage of 10k contracts
     const result = getContextWindow('gemini-2.5-pro', 10000);
-    expect(result).toBeLessThan(2000000);
+    expect(result).toBeLessThan(1048576);
     expect(result).toBeGreaterThanOrEqual(32000);
   });
 
@@ -137,11 +157,32 @@ describe('formatDuration', () => {
 });
 
 describe('getModelPricing', () => {
-  it('returns pricing for claude-opus-4', () => {
+  it('returns pricing for claude-opus-4 (deprecated)', () => {
     const p = getModelPricing('claude-opus-4-20250514');
     expect(p).not.toBeNull();
     expect(p!.input).toBe(15);
     expect(p!.output).toBe(75);
+  });
+
+  it('returns pricing for claude-opus-4-6', () => {
+    const p = getModelPricing('claude-opus-4-6');
+    expect(p).not.toBeNull();
+    expect(p!.input).toBe(5);
+    expect(p!.output).toBe(25);
+  });
+
+  it('strips [1m] suffix for pricing lookup', () => {
+    const p = getModelPricing('claude-opus-4-6[1m]');
+    expect(p).not.toBeNull();
+    expect(p!.input).toBe(5);
+    expect(p!.output).toBe(25);
+  });
+
+  it('returns updated pricing for claude-haiku-4', () => {
+    const p = getModelPricing('claude-haiku-4-5');
+    expect(p).not.toBeNull();
+    expect(p!.input).toBe(1);
+    expect(p!.output).toBe(5);
   });
 
   it('returns pricing for gemini-2.5-pro', () => {

--- a/frontend/src/components/dashboard/__tests__/utils.test.ts
+++ b/frontend/src/components/dashboard/__tests__/utils.test.ts
@@ -13,6 +13,7 @@ import {
   estimateCost,
   formatCost,
   formatTokenCount,
+  isModelRecognized,
 } from '../utils';
 
 describe('getContextWindow', () => {
@@ -75,6 +76,32 @@ describe('getContextWindow', () => {
 
   it('returns baseMax when no tokens used', () => {
     expect(getContextWindow('gpt-4o', 0)).toBe(128000);
+  });
+});
+
+describe('isModelRecognized', () => {
+  it('returns true for known claude model', () => {
+    expect(isModelRecognized('claude-opus-4-6')).toBe(true);
+  });
+
+  it('returns true for known model with [1m] suffix', () => {
+    expect(isModelRecognized('claude-opus-4-6[1m]')).toBe(true);
+  });
+
+  it('returns true for known gemini model', () => {
+    expect(isModelRecognized('gemini-2.5-pro-latest')).toBe(true);
+  });
+
+  it('returns false for unknown model', () => {
+    expect(isModelRecognized('some-new-model-v9')).toBe(false);
+  });
+
+  it('returns true for undefined model', () => {
+    expect(isModelRecognized()).toBe(true);
+  });
+
+  it('returns true for empty string', () => {
+    expect(isModelRecognized('')).toBe(true);
   });
 });
 

--- a/frontend/src/components/dashboard/utils.ts
+++ b/frontend/src/components/dashboard/utils.ts
@@ -116,6 +116,23 @@ export const getContextWindow = (
 };
 
 /**
+ * Returns true if the model string matches a known entry in
+ * the CONTEXT_WINDOWS map. Returns true for undefined/empty
+ * model (no warning when telemetry hasn't reported yet).
+ *
+ * Use this to flag models that may need to be added to the
+ * hardcoded lookup tables.
+ */
+export const isModelRecognized = (model?: string): boolean => {
+  if (!model) return true;
+  const normalized = model.toLowerCase().replace('[1m]', '');
+  for (const key of Object.keys(CONTEXT_WINDOWS)) {
+    if (normalized.includes(key)) return true;
+  }
+  return false;
+};
+
+/**
  * Returns Tailwind color classes for agent tool type badges.
  * Gemini = blue, Claude = purple, Bash = slate.
  */

--- a/frontend/src/components/dashboard/utils.ts
+++ b/frontend/src/components/dashboard/utils.ts
@@ -12,24 +12,41 @@ export const CONTEXT_TIERS = [
 /**
  * Known context window sizes keyed by partial model name.
  * Used for matching against normalized model identifiers.
+ *
+ * Key ordering is critical: `.includes()` matching stops
+ * at the first hit, so more-specific keys must precede
+ * less-specific ones within each model family.
+ *
+ * Claude models with a `[1m]` suffix (e.g.
+ * "claude-opus-4-6[1m]") use 1M context; without the
+ * suffix they default to 200k. The suffix is parsed in
+ * `getContextWindow()` before consulting this map.
+ *
+ * Last verified: 2026-04-15
  */
 export const CONTEXT_WINDOWS: Record<string, number> = {
+  // Claude — all default to 200k; 1M via [1m] suffix
+  'claude-opus-4-6': 200000,
+  'claude-sonnet-4-6': 200000,
+  'claude-opus-4-5': 200000,
+  'claude-opus-4-1': 200000,
+  'claude-opus-4': 200000,
+  'claude-sonnet-4-5': 200000,
+  'claude-sonnet-4': 200000,
+  'claude-haiku-4': 200000,
   'claude-3-5': 200000,
   'claude-3': 200000,
-  'claude-opus-4': 1000000,
-  'claude-sonnet-4': 1000000,
-  'claude-haiku-4': 1000000,
-  'gemini-3.1-pro': 2000000,
-  'gemini-3.1-flash': 1000000,
-  'gemini-3-flash': 1000000,
-  'gemini-2.5-pro': 2000000,
-  'gemini-2.5-flash': 1000000,
-  'gemini-2.0-flash': 1000000,
-  'gemini-1.5-pro': 2000000,
-  'gemini-exp': 2000000,
-  'gemini-1.5-flash': 1000000,
-  'gpt-4': 128000,
+  // Gemini — all 1,048,576 input tokens
+  'gemini-3.1-pro': 1048576,
+  'gemini-3.1-flash': 1048576,
+  'gemini-3-flash': 1048576,
+  'gemini-2.5-pro': 1048576,
+  'gemini-2.5-flash-lite': 1048576,
+  'gemini-2.5-flash': 1048576,
+  'gemini-2.0-flash': 1048576,
+  // GPT
   'gpt-4o': 128000,
+  'gpt-4': 128000,
 };
 
 /**
@@ -44,9 +61,15 @@ export const getContextWindow = (
 ): number => {
   let baseMax = 200000;
   if (model) {
-    const normalizedModel = model.toLowerCase();
-    let found = false;
+    let normalizedModel = model.toLowerCase();
 
+    // Detect [1m] context suffix (e.g. "claude-opus-4-6[1m]")
+    const has1mSuffix = normalizedModel.includes('[1m]');
+    if (has1mSuffix) {
+      normalizedModel = normalizedModel.replace('[1m]', '');
+    }
+
+    let found = false;
     for (const [key, size] of Object.entries(CONTEXT_WINDOWS)) {
       if (normalizedModel.includes(key)) {
         baseMax = size;
@@ -55,8 +78,13 @@ export const getContextWindow = (
       }
     }
     if (!found) {
-      if (normalizedModel.includes('gemini')) baseMax = 1000000;
+      if (normalizedModel.includes('gemini')) baseMax = 1048576;
       else if (normalizedModel.includes('claude')) baseMax = 200000;
+    }
+
+    // Override with 1M if the [1m] suffix was present
+    if (has1mSuffix) {
+      baseMax = 1_000_000;
     }
   }
 
@@ -128,7 +156,7 @@ export const getProgressColor = (pct: number): string => {
  * cost directly (e.g. Gemini). Claude Code reports its own
  * cost via OTLP so these are only used as fallback.
  *
- * Last verified: 2026-03-24
+ * Last verified: 2026-04-15
  */
 export interface ModelPricing {
   /** Dollars per million input tokens. */
@@ -142,11 +170,32 @@ export interface ModelPricing {
 }
 
 export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Claude — ordered most-specific first
+  'claude-opus-4-6': {
+    input: 5,
+    output: 25,
+    cacheRead: 0.5,
+    cacheWrite: 6.25,
+  },
+  'claude-sonnet-4-6': {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheWrite: 3.75,
+  },
+  'claude-opus-4-5': { input: 5, output: 25 },
+  'claude-opus-4-1': { input: 15, output: 75 },
   'claude-opus-4': {
     input: 15,
     output: 75,
     cacheRead: 1.5,
     cacheWrite: 18.75,
+  },
+  'claude-sonnet-4-5': {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheWrite: 3.75,
   },
   'claude-sonnet-4': {
     input: 3,
@@ -155,10 +204,10 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
     cacheWrite: 3.75,
   },
   'claude-haiku-4': {
-    input: 0.8,
-    output: 4,
-    cacheRead: 0.08,
-    cacheWrite: 1,
+    input: 1,
+    output: 5,
+    cacheRead: 0.1,
+    cacheWrite: 1.25,
   },
   'claude-3-5-sonnet': {
     input: 3,
@@ -172,6 +221,7 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
     cacheRead: 0.08,
     cacheWrite: 1,
   },
+  // Gemini
   'gemini-3.1-pro': { input: 2, output: 12 },
   'gemini-3.1-flash': { input: 0.25, output: 1.5 },
   'gemini-3-flash': { input: 0.5, output: 3 },
@@ -186,7 +236,7 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
  */
 export const getModelPricing = (model?: string): ModelPricing | null => {
   if (!model) return null;
-  const normalized = model.toLowerCase();
+  const normalized = model.toLowerCase().replace('[1m]', '');
   for (const [key, pricing] of Object.entries(MODEL_PRICING)) {
     if (normalized.includes(key)) return pricing;
   }


### PR DESCRIPTION
## Summary

- **Fix incorrect context window sizes** for all Claude and Gemini models against official documentation from [Anthropic](https://platform.claude.com/docs/en/docs/about-claude/models) and [Google AI](https://ai.google.dev/gemini-api/docs/models)
- **Add `[1m]` suffix parsing** so Claude models reporting extended context (e.g. `claude-opus-4-6[1m]`) correctly show a 1M context window instead of the 200k default
- **Correct and expand pricing data** — adds Opus 4.6 ($5/$25), Sonnet 4.6, Opus 4.5, Opus 4.1, Sonnet 4.5; updates Haiku 4.5 from $0.80/$4 to $1/$5
- **Add unrecognized model warning** — an amber TriangleAlert icon appears next to the model name when it doesn't match any entry in the lookup tables, helping developers know when records need updating

### Key corrections
| Area | Before | After |
|------|--------|-------|
| Claude Opus/Sonnet 4.x context | 1M (all) | 200k default, 1M only with `[1m]` suffix |
| Claude Haiku 4.5 context | 1M | 200k |
| Gemini 2.5 Pro context | 2M | 1,048,576 |
| Gemini 3.1 Pro context | 2M | 1,048,576 |
| All other Gemini context | 1M | 1,048,576 |
| Claude Opus 4.6 pricing | $15/$75 (old 4.0 rate) | $5/$25 |
| Claude Haiku 4.5 pricing | $0.80/$4 | $1/$5 |

## Test plan

- [x] All 58 frontend tests pass (`npx vitest run`)
- [x] Prettier formatting clean
- [x] ESLint clean
- [x] Pre-commit hooks pass
- [ ] Visual check: verify amber warning icon appears for unrecognized model names

🤖 Generated with [Claude Code](https://claude.com/claude-code)