### PR TITLE
Add version display and upgrade notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,12 +237,12 @@ jobs:
       - name: Build backend container
         run: |
           podman build --no-cache -t agent-dashboard-backend \
-            -f backend/Containerfile backend/
+            -f backend/Containerfile .
 
       - name: Build frontend container
         run: |
           podman build --no-cache -t agent-dashboard-frontend \
-            -f frontend/Containerfile frontend/
+            -f frontend/Containerfile .
 
       - name: Build agent daemon container
         run: |

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ session cost.
   derived from OTLP activity and terminal output patterns.
 - **MCP server detection** — Detects configured MCP servers from
   `.mcp.json`, `~/.claude.json`, or `~/.gemini/settings.json`.
+- **Version & upgrade notification** — The dashboard header
+  displays the current version (auto-detected from git tags at
+  build time) and checks GitHub for newer releases, showing a
+  subtle upgrade indicator when one is available.
 
 ## Getting Started
 

--- a/backend/Containerfile
+++ b/backend/Containerfile
@@ -1,3 +1,19 @@
+# Stage 0: Detect version from git (if available)
+FROM docker.io/library/alpine:3 AS version
+RUN apk add --no-cache git
+# Use glob pattern .gi[t] so COPY succeeds even when
+# .git is absent (e.g. building from a tarball).
+COPY .gi[t] /tmp/.git
+ARG APP_VERSION=
+RUN if [ -d /tmp/.git ]; then \
+        git -C /tmp describe --always --dirty > /tmp/VERSION; \
+    elif [ -n "$APP_VERSION" ]; then \
+        echo "$APP_VERSION" > /tmp/VERSION; \
+    else \
+        echo "dev" > /tmp/VERSION; \
+    fi
+
+# Stage 1: Application
 FROM registry.fedoraproject.org/fedora:42
 
 WORKDIR /app
@@ -8,22 +24,14 @@ RUN dnf install --setopt=install_weak_deps=False --setopt=retries=3 -y \
     python3-pip \
     python3-devel \
     gcc \
-    git \
     && dnf clean all
 
 # Copy requirements and install
 COPY backend/requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-# Detect version from git tags automatically.
-# Produces clean tags (v0.4.0) for releases or
-# descriptive versions (v0.4.0-3-g20799ff) for dev builds.
-# Falls back to "dev" if .git is not in the build context.
-COPY .git /tmp/.git
-RUN git -C /tmp describe --always --dirty 2>/dev/null \
-    > /app/VERSION \
-    || echo "dev" > /app/VERSION \
-    && rm -rf /tmp/.git
+# Embed detected version
+COPY --from=version /tmp/VERSION /app/VERSION
 
 # Copy application code
 COPY backend/ .

--- a/backend/Containerfile
+++ b/backend/Containerfile
@@ -8,19 +8,25 @@ RUN dnf install --setopt=install_weak_deps=False --setopt=retries=3 -y \
     python3-pip \
     python3-devel \
     gcc \
+    git \
     && dnf clean all
 
 # Copy requirements and install
-COPY requirements.txt .
+COPY backend/requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-# Embed application version (set at build time via
-# --build-arg APP_VERSION=v0.4.0 or git describe output)
-ARG APP_VERSION=dev
-RUN echo "$APP_VERSION" > /app/VERSION
+# Detect version from git tags automatically.
+# Produces clean tags (v0.4.0) for releases or
+# descriptive versions (v0.4.0-3-g20799ff) for dev builds.
+# Falls back to "dev" if .git is not in the build context.
+COPY .git /tmp/.git
+RUN git -C /tmp describe --always --dirty 2>/dev/null \
+    > /app/VERSION \
+    || echo "dev" > /app/VERSION \
+    && rm -rf /tmp/.git
 
 # Copy application code
-COPY . .
+COPY backend/ .
 
 # Ensure data directory exists for SQLite
 RUN mkdir -p /app/data

--- a/backend/Containerfile
+++ b/backend/Containerfile
@@ -14,6 +14,11 @@ RUN dnf install --setopt=install_weak_deps=False --setopt=retries=3 -y \
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
+# Embed application version (set at build time via
+# --build-arg APP_VERSION=v0.4.0 or git describe output)
+ARG APP_VERSION=dev
+RUN echo "$APP_VERSION" > /app/VERSION
+
 # Copy application code
 COPY . .
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,10 +4,13 @@ Defines Pydantic schemas, authentication endpoints, and CRUD
 operations for hosts, agents, and telemetry.
 """
 
+import asyncio
 import os
+import re
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Dict, List, Optional
 
+import httpx
 import socketio
 from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -21,6 +24,53 @@ from . import models, database, auth, socket
 
 # Initialize the database
 models.Base.metadata.create_all(bind=database.engine)
+
+# --- Version tracking ---
+# Read embedded version from /app/VERSION (written at build
+# time). Falls back to "dev" if the file doesn't exist.
+_CURRENT_VERSION = "dev"
+try:
+    with open("/app/VERSION", "r", encoding="utf-8") as _vf:
+        _CURRENT_VERSION = _vf.read().strip() or "dev"
+except FileNotFoundError:
+    pass
+
+# Regex to detect clean semver tags (e.g. v0.4.0) vs
+# development builds (e.g. v0.4.0-3-g20799ff or just a hash)
+_SEMVER_TAG = re.compile(r"^v?\d+\.\d+\.\d+$")
+
+# Cached latest release info from GitHub
+_latest_release: Dict[str, Optional[str]] = {
+    "tag": None,
+    "url": None,
+}
+
+# GitHub repo for release checks
+_GITHUB_REPO = os.getenv(
+    "GITHUB_REPO",
+    "dustinblack/agent-dashboard",
+)
+# Interval between GitHub release checks (seconds)
+_VERSION_CHECK_INTERVAL = 1800  # 30 minutes
+
+
+def _parse_semver(version: str) -> Optional[tuple]:
+    """Parses a version string into a (major, minor, patch)
+    tuple. Returns None if the version is not a clean semver
+    tag.
+    """
+    match = re.match(r"^v?(\d+)\.(\d+)\.(\d+)$", version)
+    if match:
+        return tuple(int(x) for x in match.groups())
+    return None
+
+
+def _is_dev_build(version: str) -> bool:
+    """Returns True if the version is a development build
+    (not a clean semver tag).
+    """
+    return not _SEMVER_TAG.match(version)
+
 
 fastapi_app = FastAPI(title="AI Coding Agent Dashboard API")
 
@@ -500,3 +550,69 @@ def health_check():
     Simple public health check endpoint.
     """
     return {"status": "healthy"}
+
+
+@fastapi_app.get("/version")
+def get_version():
+    """Returns current version and latest available release.
+
+    The current version is embedded at build time. The latest
+    release is fetched from GitHub periodically in the
+    background. For tagged builds, update_available is true
+    when a newer semver release exists. For development builds,
+    update_available is always false but the latest release
+    info is still returned for informational display.
+    """
+    current = _CURRENT_VERSION
+    latest = _latest_release["tag"]
+    latest_url = _latest_release["url"]
+    is_dev = _is_dev_build(current)
+
+    update_available = False
+    if not is_dev and latest:
+        current_ver = _parse_semver(current)
+        latest_ver = _parse_semver(latest)
+        if current_ver and latest_ver:
+            update_available = latest_ver > current_ver
+
+    return {
+        "current": current,
+        "is_dev": is_dev,
+        "latest": latest,
+        "latest_url": latest_url,
+        "update_available": update_available,
+    }
+
+
+async def _check_latest_release():
+    """Background task that periodically fetches the latest
+    GitHub release and caches the result. Runs every 30 minutes.
+    Errors are logged but do not affect application operation.
+    """
+    while True:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    f"https://api.github.com/repos/{_GITHUB_REPO}" "/releases/latest",
+                    headers={"Accept": "application/vnd.github.v3+json"},
+                    timeout=10,
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    _latest_release["tag"] = data.get("tag_name")
+                    _latest_release["url"] = data.get("html_url")
+                    print(
+                        f"Version check: current={_CURRENT_VERSION}"
+                        f" latest={_latest_release['tag']}"
+                    )
+                else:
+                    print(f"Version check failed: " f"HTTP {resp.status_code}")
+        except Exception as e:
+            print(f"Version check error: {e}")
+        await asyncio.sleep(_VERSION_CHECK_INTERVAL)
+
+
+@fastapi_app.on_event("startup")
+async def start_version_checker():
+    """Launches the background GitHub release checker."""
+    asyncio.create_task(_check_latest_release())

--- a/compose.yml
+++ b/compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ./backend
       dockerfile: Containerfile
+      args:
+        APP_VERSION: ${APP_VERSION:-dev}
     ports:
       - "8000:8000"
     volumes:
@@ -20,6 +22,7 @@ services:
       dockerfile: Containerfile
       args:
         VITE_API_URL: ${VITE_API_URL:-}
+        VITE_APP_VERSION: ${APP_VERSION:-dev}
     ports:
       - "8080:80"
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -3,10 +3,8 @@ version: '3.8'
 services:
   backend:
     build:
-      context: ./backend
-      dockerfile: Containerfile
-      args:
-        APP_VERSION: ${APP_VERSION:-dev}
+      context: .
+      dockerfile: backend/Containerfile
     ports:
       - "8000:8000"
     volumes:
@@ -18,11 +16,10 @@ services:
 
   frontend:
     build:
-      context: ./frontend
-      dockerfile: Containerfile
+      context: .
+      dockerfile: frontend/Containerfile
       args:
         VITE_API_URL: ${VITE_API_URL:-}
-        VITE_APP_VERSION: ${APP_VERSION:-dev}
     ports:
       - "8080:80"
     depends_on:

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -133,11 +133,13 @@ The `compose.yml` in the project root starts the hub services:
 services:
   backend:
     # FastAPI + Socket.IO hub on port 8000
+    # Build context is repo root (for git version detection)
     # Persists SQLite DB in dashboard_data volume
     # BYPASS_AUTH=true skips OIDC for private networks
 
   frontend:
     # React UI served by Nginx on port 8080
+    # Build context is repo root (for git version detection)
     # VITE_API_URL build arg configures backend connection
 ```
 
@@ -147,6 +149,12 @@ services:
 | `BYPASS_AUTH` | Set to `true` to skip OIDC auth (default in compose) |
 | `DATABASE_URL` | SQLite path inside the backend container |
 | `dashboard_data` | Named volume for database persistence |
+
+> [!NOTE]
+> Both services use the **repo root** as their build context
+> so they can detect the application version from git tags
+> automatically. The version is displayed in the dashboard
+> header and used for upgrade notifications.
 
 ## Included Tools
 

--- a/frontend/Containerfile
+++ b/frontend/Containerfile
@@ -14,6 +14,9 @@ COPY index.html tsconfig*.json vite.config.ts ./
 # Pass VITE_API_URL here if the backend is on a specific hostname
 ARG VITE_API_URL
 ENV VITE_API_URL=$VITE_API_URL
+# Embed application version for display in the dashboard header
+ARG VITE_APP_VERSION=dev
+ENV VITE_APP_VERSION=$VITE_APP_VERSION
 RUN npm run build
 
 # Stage 2: Serve with NGINX

--- a/frontend/Containerfile
+++ b/frontend/Containerfile
@@ -1,23 +1,30 @@
+# Stage 0: Detect version from git
+FROM docker.io/library/alpine:3 AS version
+RUN apk add --no-cache git
+COPY .git /tmp/.git
+RUN git -C /tmp describe --always --dirty 2>/dev/null \
+    > /tmp/VERSION \
+    || echo "dev" > /tmp/VERSION
+
 # Stage 1: Build the React app
 FROM docker.io/library/node:22-slim AS build
 
 WORKDIR /app
 
 # Copy package files and install dependencies
-COPY package*.json ./
+COPY frontend/package*.json ./
 RUN npm ci
 
 # Copy source and config files (node_modules stays from npm ci)
-COPY src/ src/
-COPY public/ public/
-COPY index.html tsconfig*.json vite.config.ts ./
+COPY frontend/src/ src/
+COPY frontend/public/ public/
+COPY frontend/index.html frontend/tsconfig*.json frontend/vite.config.ts ./
 # Pass VITE_API_URL here if the backend is on a specific hostname
 ARG VITE_API_URL
 ENV VITE_API_URL=$VITE_API_URL
-# Embed application version for display in the dashboard header
-ARG VITE_APP_VERSION=dev
-ENV VITE_APP_VERSION=$VITE_APP_VERSION
-RUN npm run build
+# Embed application version detected from git
+COPY --from=version /tmp/VERSION /tmp/VERSION
+RUN export VITE_APP_VERSION=$(cat /tmp/VERSION) && npm run build
 
 # Stage 2: Serve with NGINX
 FROM registry.fedoraproject.org/fedora-minimal:42
@@ -35,7 +42,7 @@ RUN rm -f /etc/nginx/conf.d/default.conf \
     && sed -i '/^    server {/,/^    }/d' /etc/nginx/nginx.conf
 
 # Copy custom NGINX configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy build output from Stage 1
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/frontend/Containerfile
+++ b/frontend/Containerfile
@@ -1,10 +1,17 @@
-# Stage 0: Detect version from git
+# Stage 0: Detect version from git (if available)
 FROM docker.io/library/alpine:3 AS version
 RUN apk add --no-cache git
-COPY .git /tmp/.git
-RUN git -C /tmp describe --always --dirty 2>/dev/null \
-    > /tmp/VERSION \
-    || echo "dev" > /tmp/VERSION
+# Use glob pattern .gi[t] so COPY succeeds even when
+# .git is absent (e.g. building from a tarball).
+COPY .gi[t] /tmp/.git
+ARG APP_VERSION=
+RUN if [ -d /tmp/.git ]; then \
+        git -C /tmp describe --always --dirty > /tmp/VERSION; \
+    elif [ -n "$APP_VERSION" ]; then \
+        echo "$APP_VERSION" > /tmp/VERSION; \
+    else \
+        echo "dev" > /tmp/VERSION; \
+    fi
 
 # Stage 1: Build the React app
 FROM docker.io/library/node:22-slim AS build

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -122,4 +122,17 @@ export const getMe = async () => {
   return response.data;
 };
 
+export interface VersionInfo {
+  current: string;
+  is_dev: boolean;
+  latest: string | null;
+  latest_url: string | null;
+  update_available: boolean;
+}
+
+export const getVersion = async (): Promise<VersionInfo> => {
+  const response = await api.get('/version');
+  return response.data;
+};
+
 export default api;

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { getHosts, getAgents, spawnAgent, stopAgent, deleteHost } from '../api';
-import type { Host, Agent } from '../api';
+import {
+  getHosts,
+  getAgents,
+  spawnAgent,
+  stopAgent,
+  deleteHost,
+  getVersion,
+} from '../api';
+import type { Host, Agent, VersionInfo } from '../api';
 import { Cpu, Activity } from 'lucide-react';
 import { io } from 'socket.io-client';
 import LogoSvg from './LogoSvg';
@@ -22,6 +29,15 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
     hostId: number;
     tool: string;
   } | null>(null);
+  const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
+
+  // Fetch version info on mount
+  const appVersion = import.meta.env.VITE_APP_VERSION || 'dev';
+  useEffect(() => {
+    getVersion()
+      .then(setVersionInfo)
+      .catch(() => {}); // Degrade gracefully
+  }, []);
 
   const projectsCache = useRef<Record<number, Host['projects']>>({});
 
@@ -218,6 +234,39 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
         <h1 className="text-3xl font-bold flex items-center gap-3 text-slate-50">
           <LogoSvg className="w-9 h-9" />
           Agent Dashboard
+          <span className="text-xs font-normal text-slate-500 font-mono self-end mb-0.5">
+            {appVersion}
+            {versionInfo?.update_available && versionInfo.latest && (
+              <>
+                {' '}
+                <span className="text-slate-600">→</span>{' '}
+                <a
+                  href={versionInfo.latest_url || '#'}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  {versionInfo.latest} available
+                </a>
+              </>
+            )}
+            {!versionInfo?.update_available &&
+              versionInfo?.is_dev &&
+              versionInfo?.latest && (
+                <>
+                  {' '}
+                  <span className="text-slate-600">·</span>{' '}
+                  <a
+                    href={versionInfo.latest_url || '#'}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-slate-500 hover:underline"
+                  >
+                    latest: {versionInfo.latest}
+                  </a>
+                </>
+              )}
+          </span>
         </h1>
         <div className="flex items-center gap-4">
           <ThemeSelector />


### PR DESCRIPTION
## Summary

- **Version display** — The dashboard header now shows the current application version next to the title. Tagged releases show the clean tag (e.g. `v0.5.0`); development builds show the git describe output (e.g. `v0.4.0-3-g20799ff`).
- **Upgrade notification** — The backend periodically checks the GitHub releases API (every 30 minutes) and caches the latest release. When a newer version is available, the header augments with a linked indicator:
  - Tagged build: `v0.4.0 → v0.5.0 available` (accent color, links to release page)
  - Dev build: `v0.4.0-3-g20799ff · latest: v0.5.0` (informational, links to release page)
- **Automatic version detection** — Version is detected from git tags at container build time using a lightweight alpine+git build stage. No manual build args needed. Falls back gracefully:
  1. `.git` present: auto-detected via `git describe --always --dirty`
  2. `.git` absent + `APP_VERSION` build arg: uses provided value
  3. Neither: falls back to `dev`

## Changes

| File | What |
|------|------|
| `backend/Containerfile` | Multi-stage build with git version detection, repo-root context |
| `backend/app/main.py` | Add `/version` endpoint, background GitHub release checker, semver parsing |
| `frontend/Containerfile` | Multi-stage build with git version detection, repo-root context |
| `frontend/src/api.ts` | Add `VersionInfo` interface and `getVersion()` function |
| `frontend/src/components/Dashboard.tsx` | Version display in header with conditional upgrade indicator |
| `compose.yml` | Build contexts changed to repo root for git access |
| `README.md` | Add version feature to Telemetry & Monitoring section |
| `docs/host-daemon.md` | Document build context and version detection in compose reference |

## Test plan

- [ ] `podman-compose build` from a tagged commit — version shows clean tag in header
- [ ] `podman-compose build` from a non-tagged commit — shows git describe output (e.g. `v0.4.0-3-g20799ff`)
- [ ] Build from a tarball (no .git) — shows `dev`
- [ ] When a newer GitHub release exists, upgrade indicator appears with link
- [ ] Dev build shows "latest: vX.Y.Z" informationally
- [ ] Current version matches latest — no upgrade indicator
- [ ] GitHub API unreachable — degrades gracefully, just shows version
- [ ] `/version` endpoint returns correct JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)