### PR TITLE
Fix context window bar showing 32k for recognized 1M models

### DIFF
--- a/frontend/src/components/dashboard/__tests__/utils.test.ts
+++ b/frontend/src/components/dashboard/__tests__/utils.test.ts
@@ -67,11 +67,25 @@ describe('getContextWindow', () => {
     expect(result).toBeGreaterThan(250000);
   });
 
-  it('contracts on very low usage', () => {
-    // gemini-2.5-pro base is 1048576; usage of 10k contracts
+  it('does not contract recognized models', () => {
+    // gemini-2.5-pro is in the catalog — should always
+    // return its actual context window regardless of low
+    // token usage.
     const result = getContextWindow('gemini-2.5-pro', 10000);
-    expect(result).toBeLessThan(1048576);
-    expect(result).toBeGreaterThanOrEqual(32000);
+    expect(result).toBe(1048576);
+  });
+
+  it('contracts unrecognized models with 128k floor', () => {
+    // Unknown model defaults to 200k; low usage should
+    // contract but not below 128k.
+    const result = getContextWindow('mystery-model-v1', 5000);
+    expect(result).toBe(128000);
+  });
+
+  it('does not contract unrecognized model above floor', () => {
+    // If usage * 1.5 exceeds 128k, contract to that tier
+    const result = getContextWindow('mystery-model-v1', 100000);
+    expect(result).toBe(200000);
   });
 
   it('returns baseMax when no tokens used', () => {

--- a/frontend/src/components/dashboard/utils.ts
+++ b/frontend/src/components/dashboard/utils.ts
@@ -60,6 +60,11 @@ export const getContextWindow = (
   tokensUsed: number = 0,
 ): number => {
   let baseMax = 200000;
+  // Track whether the model was matched in the catalog
+  // or a known family. Contraction only applies to truly
+  // unrecognized models where the context window is a
+  // blind default.
+  let recognized = false;
   if (model) {
     let normalizedModel = model.toLowerCase();
 
@@ -69,29 +74,36 @@ export const getContextWindow = (
       normalizedModel = normalizedModel.replace('[1m]', '');
     }
 
-    let found = false;
     for (const [key, size] of Object.entries(CONTEXT_WINDOWS)) {
       if (normalizedModel.includes(key)) {
         baseMax = size;
-        found = true;
+        recognized = true;
         break;
       }
     }
-    if (!found) {
-      if (normalizedModel.includes('gemini')) baseMax = 1048576;
-      else if (normalizedModel.includes('claude')) baseMax = 200000;
+    if (!recognized) {
+      // Family-level fallbacks for models not yet in the
+      // catalog but belonging to a known provider family.
+      if (normalizedModel.includes('gemini')) {
+        baseMax = 1048576;
+        recognized = true;
+      } else if (normalizedModel.includes('claude')) {
+        baseMax = 200000;
+        recognized = true;
+      }
     }
 
     // Override with 1M if the [1m] suffix was present
     if (has1mSuffix) {
       baseMax = 1_000_000;
+      recognized = true;
     }
   }
 
   if (!tokensUsed) return baseMax;
 
   // Expansion: If tokens exceed the hardcoded limit,
-  // expand to next tier.
+  // expand to next tier so the bar doesn't pin at 100%.
   if (tokensUsed >= baseMax) {
     const higherTiers = CONTEXT_TIERS.filter((t) => t > tokensUsed);
     return higherTiers.length > 0
@@ -99,16 +111,19 @@ export const getContextWindow = (
       : Math.ceil(tokensUsed * 1.5);
   }
 
-  // Contraction: If usage is very low compared to the
-  // hardcoded baseMax, dynamically contract the visual
-  // maximum so the progress bar remains meaningful.
-  const idealMax = Math.max(tokensUsed * 1.5, 32000);
-  if (idealMax < baseMax) {
-    const lowerTiers = CONTEXT_TIERS.filter(
-      (t) => t >= idealMax && t <= baseMax,
-    );
-    if (lowerTiers.length > 0) {
-      return lowerTiers[0];
+  // Contraction: For unrecognized models only, use token
+  // usage to heuristically guess a reasonable context
+  // window. Floor at 128k since the smallest known modern
+  // model context is 128k (GPT-4o).
+  if (!recognized) {
+    const idealMax = Math.max(tokensUsed * 1.5, 128000);
+    if (idealMax < baseMax) {
+      const lowerTiers = CONTEXT_TIERS.filter(
+        (t) => t >= idealMax && t <= baseMax,
+      );
+      if (lowerTiers.length > 0) {
+        return lowerTiers[0];
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Context window contraction logic was applying to all models, causing recognized models like `claude-opus-4-6[1m]` (1M context) to display as low as 32k when token usage was low
- Gate contraction behind a `recognized` flag so it only applies to truly unknown models as a heuristic guess
- Raise the contraction floor from 32k to 128k to match the smallest known modern model context window (GPT-4o)

## Test plan
- [x] All 56 existing unit tests pass
- [x] New tests verify recognized models are never contracted
- [x] New tests verify unrecognized models contract with updated 128k floor
- [ ] Visual verification: dashboard should show "1M" for `claude-opus-4-6[1m]` regardless of token usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)