### PR TITLE
Fix version detection for lightweight git tags

### DIFF
--- a/backend/Containerfile
+++ b/backend/Containerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache git
 COPY .gi[t] /tmp/.git
 ARG APP_VERSION=
 RUN if [ -d /tmp/.git ]; then \
-        git -C /tmp describe --always --dirty > /tmp/VERSION; \
+        git -C /tmp describe --always --tags > /tmp/VERSION; \
     elif [ -n "$APP_VERSION" ]; then \
         echo "$APP_VERSION" > /tmp/VERSION; \
     else \

--- a/frontend/Containerfile
+++ b/frontend/Containerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache git
 COPY .gi[t] /tmp/.git
 ARG APP_VERSION=
 RUN if [ -d /tmp/.git ]; then \
-        git -C /tmp describe --always --dirty > /tmp/VERSION; \
+        git -C /tmp describe --always --tags > /tmp/VERSION; \
     elif [ -n "$APP_VERSION" ]; then \
         echo "$APP_VERSION" > /tmp/VERSION; \
     else \


### PR DESCRIPTION
## Summary

- Add `--tags` flag to `git describe` in both Containerfiles so lightweight tags (the default when creating tags via GitHub releases) are recognized. Without this flag, `git describe` only matches annotated tags and falls back to the commit hash — causing the dashboard to show `b226a63` instead of `v0.5.0`.
- Drop `--dirty` flag since it reports on the build context state rather than the source tree, causing misleading `-dirty` suffixes when untracked files exist in the repo root during container builds.

## Test plan

- [ ] Build from a lightweight-tagged commit — dashboard shows `v0.5.0` (not commit hash)
- [ ] Build from a commit ahead of a tag — shows `v0.5.0-3-g1234567`
- [ ] Build from a repo with no tags — shows commit hash
- [ ] No `-dirty` suffix in any case

🤖 Generated with [Claude Code](https://claude.com/claude-code)