### PR TITLE
Add macOS deployment tips and daemon reconfiguration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ A container runtime with compose support on the hub server:
 | Debian / Ubuntu | `sudo apt install podman podman-compose` or install [Docker Engine](https://docs.docker.com/engine/install/) |
 | macOS | `brew install podman podman-compose` or install [Docker Desktop](https://www.docker.com/products/docker-desktop/) |
 
+> [!NOTE]
+> **macOS (Podman):** Podman on macOS runs containers inside
+> a Linux VM. Initialize and start it before running any
+> container commands:
+> ```bash
+> podman machine init
+> podman machine start
+> ```
+> You only need to run `init` once. After reboots, just run
+> `podman machine start`.
+
 ### 1. Start the Hub
 
 ```bash
@@ -221,6 +232,24 @@ podman run -d --name host-daemon --network=host --privileged \
   -v $HOME/.gemini/:/root/.gemini \
   localhost/agent-dashboard-daemon:latest
 ```
+
+> [!TIP]
+> **Missing config directories:** The volume mounts above
+> expect `~/.claude/` and `~/.gemini/` to exist on the host.
+> If you haven't used one of these tools locally, create the
+> directory first:
+> ```bash
+> mkdir -p ~/.claude ~/.gemini
+> ```
+
+> [!TIP]
+> **Reconfiguring the daemon:** To change environment
+> variables or volume mounts, stop and remove the existing
+> container, then re-run with the new parameters:
+> ```bash
+> podman stop host-daemon && podman rm host-daemon
+> # Re-run the podman run command with updated settings
+> ```
 
 > See the [Host Daemon Reference](docs/host-daemon.md) for the
 > full list of environment variables, volume mounts, and

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -38,6 +38,23 @@ podman run -d --name host-daemon --network=host \
 > development sessions). This also implicitly disables SELinux
 > label confinement.
 
+> [!TIP]
+> **Missing config directories:** Volume mounts for
+> `~/.claude/` and `~/.gemini/` will fail if the directories
+> don't exist on the host. If you haven't used one of these
+> tools locally, create them first: `mkdir -p ~/.claude
+> ~/.gemini`
+
+> [!TIP]
+> **Reconfiguring the daemon:** Environment variables and
+> volume mounts are fixed at container creation time. To
+> change them, stop and remove the existing container, then
+> re-run with the new parameters:
+> ```bash
+> podman stop host-daemon && podman rm host-daemon
+> # Re-run the podman run command with updated settings
+> ```
+
 ## Environment Variables
 
 | Variable | Description | Default |


### PR DESCRIPTION
## Summary

- Add macOS-specific note about initializing the Podman VM (`podman machine init` / `podman machine start`) in the prerequisites section
- Document that `~/.claude/` and `~/.gemini/` directories must exist on the host before starting the daemon, since volume mounts fail if missing
- Add tip for reconfiguring the daemon (stop, remove, re-run with new params)
- Mirror both tips in `docs/host-daemon.md` alongside the full run command

Based on real-world feedback from a user who deployed the hub and host daemon to a MacBook.

## Test plan

- [ ] Verify rendered markdown looks correct in the README and host-daemon doc
- [ ] Confirm the `podman machine init/start` instructions are accurate for macOS
- [ ] Verify no existing content was removed or altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)