### PR TITLE
Fix force refresh of project list in spawn modal

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -147,7 +147,9 @@ class HostDaemon:
 
         @self.sio.on("request_projects", namespace="/terminal")
         async def on_request_projects(data):
-            await self.report_projects()
+            # Force a rescan rather than reporting cached
+            # data, so the user gets an up-to-date list.
+            await self.scan_and_report_projects()
 
         @self.sio.on("terminal_resize", namespace="/terminal")
         async def on_terminal_resize(data):
@@ -329,6 +331,40 @@ class HostDaemon:
 
         print(f"Available tools: {tools}")
         return tools
+
+    async def scan_and_report_projects(self):
+        """Rescans PROJECTS_ROOT and reports the updated
+        project list to the Hub. Used for force-refresh
+        requests from the UI.
+        """
+        loop = asyncio.get_running_loop()
+
+        def _scan():
+            projects = []
+            if os.path.exists(self.projects_root):
+                try:
+                    for root, dirs, _files in os.walk(self.projects_root):
+                        rel_path = os.path.relpath(root, self.projects_root)
+                        depth = 0 if rel_path == "." else len(rel_path.split(os.sep))
+                        if depth > self.projects_depth:
+                            dirs[:] = []
+                            continue
+                        if ".git" in dirs:
+                            if rel_path != ".":
+                                projects.append(rel_path)
+                            dirs[:] = [d for d in dirs if d != ".git"]
+                    projects.sort()
+                except Exception as e:
+                    print(
+                        f"Error scanning projects root {self.projects_root}: {e}"
+                    )
+            return projects
+
+        new_projects = await loop.run_in_executor(None, _scan)
+        async with self.projects_lock:
+            self.cached_projects = new_projects
+        print(f"Force rescan: found {len(new_projects)} projects.")
+        await self.report_projects()
 
     async def report_projects(self):
         """Instantly reports cached projects and available

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -355,9 +355,7 @@ class HostDaemon:
                             dirs[:] = [d for d in dirs if d != ".git"]
                     projects.sort()
                 except Exception as e:
-                    print(
-                        f"Error scanning projects root {self.projects_root}: {e}"
-                    )
+                    print(f"Error scanning projects root {self.projects_root}: {e}")
             return projects
 
         new_projects = await loop.run_in_executor(None, _scan)

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -314,7 +314,7 @@ class TestGetGitInfo:
                     b"main\n",
                     b"git@github.com:user/my-repo.git\n",
                 ]
-                branch, project = daemon.get_git_info("/tmp/repo")  # nosec B108
+                branch, project, _url = daemon.get_git_info("/tmp/repo")  # nosec B108
         assert branch == "main"
         assert project == "my-repo"
 
@@ -327,13 +327,13 @@ class TestGetGitInfo:
                     subprocess.CalledProcessError(1, "git"),
                     b"/home/user/my-project\n",
                 ]
-                branch, project = daemon.get_git_info("/tmp/repo")  # nosec B108
+                branch, project, _url = daemon.get_git_info("/tmp/repo")  # nosec B108
         assert branch == "feature-branch"
         assert project == "my-project"
 
     def test_nonexistent_path(self, daemon):
         """Returns None, None for paths that don't exist."""
-        branch, project = daemon.get_git_info("/nonexistent/path/xyz")
+        branch, project, _url = daemon.get_git_info("/nonexistent/path/xyz")
         assert branch is None
         assert project is None
 
@@ -342,13 +342,13 @@ class TestGetGitInfo:
         with patch("subprocess.check_output") as mock_co:
             mock_co.side_effect = subprocess.CalledProcessError(128, "git")
             with patch("os.path.exists", return_value=True):
-                branch, project = daemon.get_git_info("/tmp/nogit")  # nosec B108
+                branch, project, _url = daemon.get_git_info("/tmp/nogit")  # nosec B108
         assert branch is None
         assert project is None
 
     def test_empty_path(self, daemon):
         """Returns None, None for empty string path."""
-        branch, project = daemon.get_git_info("")
+        branch, project, _url = daemon.get_git_info("")
         assert branch is None
         assert project is None
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -30,6 +30,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
     tool: string;
   } | null>(null);
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
+  const socketRef = useRef<ReturnType<typeof io> | null>(null);
 
   // Fetch version info on mount
   const appVersion = import.meta.env.VITE_APP_VERSION || 'dev';
@@ -119,14 +120,9 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
   };
 
   const requestProjects = () => {
-    const baseURL =
-      import.meta.env.VITE_API_URL || `http://${window.location.hostname}:8000`;
-    const socket = io(`${baseURL}/terminal`, {
-      path: '/socket.io',
-    });
-    socket.emit('request_projects', {});
-    console.log('Manual project refresh requested.');
-    setTimeout(() => socket.disconnect(), 1000);
+    if (socketRef.current?.connected) {
+      socketRef.current.emit('request_projects', {});
+    }
   };
 
   useEffect(() => {
@@ -136,6 +132,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
     const socket = io(`${baseURL}/terminal`, {
       path: '/socket.io',
     });
+    socketRef.current = socket;
 
     socket.on('connect', () => {
       socket.emit('request_projects', {});

--- a/frontend/src/components/dashboard/SpawnModal.tsx
+++ b/frontend/src/components/dashboard/SpawnModal.tsx
@@ -110,7 +110,7 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
               </label>
               <button
                 onClick={onRefresh}
-                className="text-[10px] text-accent font-bold uppercase tracking-tighter transition-colors flex items-center gap-1"
+                className="text-[10px] text-accent font-bold uppercase tracking-tighter transition-colors flex items-center gap-1 cursor-pointer hover:text-accent-hover hover:underline"
               >
                 <RefreshCw size={10} className="animate-spin-slow" /> Force
                 Refresh


### PR DESCRIPTION
## Summary

- **Daemon:** `on_request_projects` now triggers a full rescan of `PROJECTS_ROOT` instead of just reporting the cached list.
- **Frontend:** `requestProjects()` uses the persistent Socket.IO connection instead of creating a temporary one that disconnects before the response arrives.

## Test plan

- [ ] Click "Force Refresh" in the spawn modal — project list updates
- [ ] New repos added to `PROJECTS_ROOT` appear after refresh

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)