### PR TITLE
Make project and branch names clickable links to remote repo

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -292,19 +292,51 @@ class HostDaemon:
                 namespace="/terminal",
             )
 
-    def get_git_info(self, path: str):
-        """Extracts git branch and project name from a directory.
+    @staticmethod
+    def _remote_to_web_url(remote_url: str) -> str | None:
+        """Converts a git remote URL to an HTTPS web URL.
 
-        The project name is derived from the remote origin URL when
-        available, falling back to the git repository's root directory
-        name (e.g. a repo at /git/agent-dashboard yields
-        "agent-dashboard").
+        Handles SSH and HTTPS formats:
+        - git@github.com:user/repo.git → https://github.com/user/repo
+        - https://github.com/user/repo.git → https://github.com/user/repo
+        - git@gitlab.internal:group/repo.git → https://gitlab.internal/group/repo
+
+        Returns None if the URL format is not recognized.
+        """
+        if not remote_url:
+            return None
+        url = remote_url.strip()
+        # SSH format: git@host:path.git
+        if url.startswith("git@"):
+            url = url[4:]  # Remove git@
+            url = url.replace(":", "/", 1)  # host:path → host/path
+            url = "https://" + url
+        # Ensure https://
+        if not url.startswith("http"):
+            return None
+        # Remove .git suffix
+        if url.endswith(".git"):
+            url = url[:-4]
+        return url
+
+    def get_git_info(self, path: str):
+        """Extracts git branch, project name, and remote web
+        URL from a directory.
+
+        The project name is derived from the remote origin URL
+        when available, falling back to the git repository's
+        root directory name. The web URL is the HTTPS version
+        of the remote origin for linking in the UI.
+
+        Returns:
+            A (branch, project, remote_url) tuple.
         """
         if not path or not os.path.exists(path):
-            return None, None
+            return None, None, None
 
         branch = None
         project = None
+        remote_url = None
 
         try:
             branch = (
@@ -330,6 +362,7 @@ class HostDaemon:
                 .strip()
             )
             project = origin.rsplit("/", maxsplit=1)[-1].replace(".git", "")
+            remote_url = self._remote_to_web_url(origin)
         except Exception:
             # No remote configured — use the repo root directory name
             try:
@@ -346,7 +379,7 @@ class HostDaemon:
             except Exception:
                 pass
 
-        return branch, project
+        return branch, project, remote_url
 
     def _detect_mcp_servers(self, project_dir, tool):
         """Detects MCP servers configured for the given tool and project.
@@ -520,13 +553,14 @@ class HostDaemon:
             f"mode: {session_mode} in {full_path}"
         )
 
-        branch, project = self.get_git_info(full_path)
+        branch, project, remote_url = self.get_git_info(full_path)
         mcp_servers = self._detect_mcp_servers(original_project_dir, tool)
         telemetry = {
             "project_dir": original_project_dir,
             "task_description": task,
             "git_branch": branch,
             "git_project": project,
+            "git_remote_url": remote_url,
             "model": "detecting...",
             "tokens": 0,
             "input_tokens": 0,
@@ -1337,7 +1371,7 @@ class HostDaemon:
                         continue
                     # Try to read the cwd of the child process
                     cwd = os.readlink(f"/proc/{pid}/cwd")
-                    branch, project = self.get_git_info(cwd)
+                    branch, project, remote_url = self.get_git_info(cwd)
 
                     tel = info["telemetry"]
                     changed = False
@@ -1346,6 +1380,9 @@ class HostDaemon:
                         changed = True
                     if project and tel.get("git_project") != project:
                         tel["git_project"] = project
+                        changed = True
+                    if remote_url and tel.get("git_remote_url") != remote_url:
+                        tel["git_remote_url"] = remote_url
                         changed = True
 
                     # Read PROMPT_COMMAND sidecar file for

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -33,6 +33,7 @@ export interface Agent {
     task_description?: string;
     git_branch?: string;
     git_project?: string;
+    git_remote_url?: string;
     model?: string;
     tokens?: number;
     context_tokens?: number;

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -490,6 +490,7 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
   const hostName = agentDetail?.host_name;
   const gitProject = agentDetail?.telemetry?.git_project;
   const gitBranch = agentDetail?.telemetry?.git_branch;
+  const gitRemoteUrl = agentDetail?.telemetry?.git_remote_url;
   const worktreePath = agentDetail?.telemetry?.worktree_path;
 
   // Update browser window title with host / project / branch
@@ -538,7 +539,18 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
             {gitProject && (
               <>
                 <span className="text-slate-600">/</span>
-                <span className="text-white font-semibold">{gitProject}</span>
+                {gitRemoteUrl ? (
+                  <a
+                    href={gitRemoteUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-white font-semibold hover:underline"
+                  >
+                    {gitProject}
+                  </a>
+                ) : (
+                  <span className="text-white font-semibold">{gitProject}</span>
+                )}
               </>
             )}
             {gitBranch && (
@@ -547,7 +559,18 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
                   size={12}
                   className="text-emerald-400 shrink-0 ml-1"
                 />
-                <span className="text-emerald-300">{gitBranch}</span>
+                {gitRemoteUrl ? (
+                  <a
+                    href={`${gitRemoteUrl}/tree/${gitBranch}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-emerald-300 hover:underline"
+                  >
+                    {gitBranch}
+                  </a>
+                ) : (
+                  <span className="text-emerald-300">{gitBranch}</span>
+                )}
               </>
             )}
             {worktreePath && (

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -84,9 +84,20 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
             >
               {agent.tool_name || 'gemini'}
             </span>
-            <h3 className="font-bold text-sm text-slate-50 truncate">
-              {tel.git_project || 'Agent'}
-            </h3>
+            {tel.git_remote_url ? (
+              <a
+                href={tel.git_remote_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-bold text-sm text-slate-50 truncate hover:underline"
+              >
+                {tel.git_project || 'Agent'}
+              </a>
+            ) : (
+              <h3 className="font-bold text-sm text-slate-50 truncate">
+                {tel.git_project || 'Agent'}
+              </h3>
+            )}
           </div>
           <div className="flex items-center gap-3 mt-0.5 ml-0.5">
             {tel.git_branch && (


### PR DESCRIPTION
## Summary

- **Daemon:** Add `_remote_to_web_url()` to convert SSH/HTTPS git remotes to web URLs. Return `git_remote_url` from `get_git_info()` and store in agent telemetry.
- **Terminal header:** Project name links to repo, branch name links to branch page (`{url}/tree/{branch}`).
- **Dashboard card:** Project name links to repo.
- Plain text fallback when no remote is configured.

## Test plan

- [ ] Repos with SSH remote (`git@github.com:...`) — project name is clickable
- [ ] Repos with HTTPS remote — project name is clickable
- [ ] Repos with no remote — project name is plain text
- [ ] Branch link opens correct branch page
- [ ] Links open in new tab

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)