### PR TITLE
Detect agent availability and conditionally render Spawn buttons

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -279,16 +279,74 @@ class HostDaemon:
 
             await asyncio.sleep(60)
 
+    def _detect_available_tools(self) -> list:
+        """Detects which agent CLI tools are installed and
+        configured on this host.
+
+        Checks for binary availability and basic auth
+        configuration. Bash is always available.
+
+        Returns:
+            List of tool name strings (e.g. ["gemini",
+            "claude", "bash"]).
+        """
+        tools = ["bash"]  # Always available
+
+        # Check Gemini CLI
+        try:
+            subprocess.run(
+                ["gemini", "--version"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+            # Binary exists — check for API key
+            if os.getenv("GEMINI_API_KEY"):
+                tools.append("gemini")
+            else:
+                print("Gemini CLI found but GEMINI_API_KEY not set — not advertising.")
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+        # Check Claude Code
+        try:
+            subprocess.run(
+                ["claude", "--version"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+            # Binary exists — check for auth (API key or
+            # Vertex AI credentials)
+            has_api_key = bool(os.getenv("ANTHROPIC_API_KEY"))
+            has_vertex = bool(os.getenv("CLAUDE_CODE_USE_VERTEX"))
+            if has_api_key or has_vertex:
+                tools.append("claude")
+            else:
+                print("Claude CLI found but no auth configured — not advertising.")
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+        print(f"Available tools: {tools}")
+        return tools
+
     async def report_projects(self):
-        """Instantly reports cached projects to the Hub."""
+        """Instantly reports cached projects and available
+        tools to the Hub.
+        """
         async with self.projects_lock:
             projects = list(self.cached_projects)
 
-        print(f"Reporting {len(projects)} available projects to Hub.")
+        tools = self._detect_available_tools()
+        print(f"Reporting {len(projects)} projects, {len(tools)} tools to Hub.")
         if self.sio.connected:
             await self.sio.emit(
                 "host_telemetry",
-                {"projects_root": self.projects_root, "available_projects": projects},
+                {
+                    "projects_root": self.projects_root,
+                    "available_projects": projects,
+                    "available_tools": tools,
+                },
                 namespace="/terminal",
             )
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,6 +16,7 @@ export interface Host {
   projects?: {
     projects_root: string;
     available_projects: string[];
+    available_tools?: string[];
   };
 }
 

--- a/frontend/src/components/dashboard/HostCard.tsx
+++ b/frontend/src/components/dashboard/HostCard.tsx
@@ -28,6 +28,11 @@ const HostCard: React.FC<HostCardProps> = ({
   onDeleteHost,
 }) => {
   const isOnline = host.status === 'online';
+  const availableTools = host.projects?.available_tools || [
+    'gemini',
+    'claude',
+    'bash',
+  ];
 
   return (
     <div
@@ -61,39 +66,45 @@ const HostCard: React.FC<HostCardProps> = ({
 
         {/* Row 2: Spawn + Delete buttons */}
         <div className="flex items-center gap-2 mt-2">
-          <button
-            onClick={() => onSpawnClick(host.id, 'gemini')}
-            disabled={!isOnline}
-            className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
-              isOnline
-                ? 'bg-blue-500/20 hover:bg-blue-500/40 text-blue-400 border-blue-500/30 cursor-pointer'
-                : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
-            }`}
-          >
-            <PlusCircle size={14} /> Spawn Gemini
-          </button>
-          <button
-            onClick={() => onSpawnClick(host.id, 'claude')}
-            disabled={!isOnline}
-            className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
-              isOnline
-                ? 'bg-purple-500/20 hover:bg-purple-500/40 text-purple-400 border-purple-500/30 cursor-pointer'
-                : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
-            }`}
-          >
-            <PlusCircle size={14} /> Spawn Claude
-          </button>
-          <button
-            onClick={() => onSpawnClick(host.id, 'bash')}
-            disabled={!isOnline}
-            className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
-              isOnline
-                ? 'bg-slate-700 hover:bg-slate-600 text-slate-300 border-slate-600 cursor-pointer'
-                : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
-            }`}
-          >
-            <PlusCircle size={14} /> Spawn Bash
-          </button>
+          {availableTools.includes('gemini') && (
+            <button
+              onClick={() => onSpawnClick(host.id, 'gemini')}
+              disabled={!isOnline}
+              className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
+                isOnline
+                  ? 'bg-blue-500/20 hover:bg-blue-500/40 text-blue-400 border-blue-500/30 cursor-pointer'
+                  : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
+              }`}
+            >
+              <PlusCircle size={14} /> Spawn Gemini
+            </button>
+          )}
+          {availableTools.includes('claude') && (
+            <button
+              onClick={() => onSpawnClick(host.id, 'claude')}
+              disabled={!isOnline}
+              className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
+                isOnline
+                  ? 'bg-purple-500/20 hover:bg-purple-500/40 text-purple-400 border-purple-500/30 cursor-pointer'
+                  : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
+              }`}
+            >
+              <PlusCircle size={14} /> Spawn Claude
+            </button>
+          )}
+          {availableTools.includes('bash') && (
+            <button
+              onClick={() => onSpawnClick(host.id, 'bash')}
+              disabled={!isOnline}
+              className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
+                isOnline
+                  ? 'bg-slate-700 hover:bg-slate-600 text-slate-300 border-slate-600 cursor-pointer'
+                  : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
+              }`}
+            >
+              <PlusCircle size={14} /> Spawn Bash
+            </button>
+          )}
           <button
             onClick={() => onDeleteHost(host.id)}
             className="text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 bg-red-500/20 hover:bg-red-500/40 text-red-400 border-red-500/30 cursor-pointer ml-auto"


### PR DESCRIPTION
## Summary

- **Daemon:** New `_detect_available_tools()` checks which CLI tools are installed and configured (Gemini needs binary + `GEMINI_API_KEY`, Claude needs binary + `ANTHROPIC_API_KEY` or `CLAUDE_CODE_USE_VERTEX`, Bash always available). Reports `available_tools` in host telemetry.
- **Frontend:** Spawn buttons only render for tools the host reports as available. Falls back to showing all tools for backward compatibility with older daemons.

## Test plan

- [ ] Host with only Claude configured — shows only "Spawn Claude" and "Spawn Bash"
- [ ] Host with only Gemini configured — shows only "Spawn Gemini" and "Spawn Bash"
- [ ] Host with both configured — shows all three buttons
- [ ] Host with older daemon (no `available_tools`) — shows all three (backward compat)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)