### PR TITLE
Generalize Host Daemon for Generic Agent Profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ session cost.
   any number of development machines. Spawn and manage Gemini,
   Claude, and Bash sessions across all hosts from a single
   dashboard.
+- **Extensible agent profiles** — Agent tools are defined by
+  YAML/JSON [profile configs](docs/agent-profiles.md) rather
+  than hardcoded logic. Add support for new AI agents by
+  dropping a profile file into the `agent/profiles/` directory.
 - **Remote PTY terminals** — Full `xterm-256color` terminal
   emulation via pseudo-terminals, not a log viewer or chat
   interface. Supports cursor movement, line-erase sequences,

--- a/agent/Containerfile
+++ b/agent/Containerfile
@@ -95,10 +95,12 @@ RUN pip3 install --no-cache-dir black flake8 pylint
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-# Copy the daemon script and agent profiles
-COPY host_daemon.py .
-COPY profiles.py .
-COPY profiles/ profiles/
+# Copy the daemon as a Python package so imports
+# (e.g. from agent.profiles) work correctly.
+COPY __init__.py agent/
+COPY host_daemon.py agent/
+COPY profiles.py agent/
+COPY profiles/ agent/profiles/
 
-# Use the daemon as the entrypoint
-ENTRYPOINT ["python3", "host_daemon.py"]
+# Run as a module to preserve package import paths
+ENTRYPOINT ["python3", "-m", "agent.host_daemon"]

--- a/agent/Containerfile
+++ b/agent/Containerfile
@@ -95,8 +95,10 @@ RUN pip3 install --no-cache-dir black flake8 pylint
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-# Copy the daemon script
+# Copy the daemon script and agent profiles
 COPY host_daemon.py .
+COPY profiles.py .
+COPY profiles/ profiles/
 
 # Use the daemon as the entrypoint
 ENTRYPOINT ["python3", "host_daemon.py"]

--- a/agent/README.md
+++ b/agent/README.md
@@ -6,6 +6,15 @@ The Host Daemon runs on remote development machines and manages AI agent session
 - Python 3.9+
 - A running instance of the central Dashboard Backend (Hub).
 
+## Agent Profiles
+
+The daemon uses YAML/JSON profile files to define how each
+agent tool is spawned, detected, and monitored. Bundled
+profiles for Claude, Gemini, and Bash are in `agent/profiles/`.
+Custom profiles can be added by dropping a YAML file into the
+same directory. See [Agent Profiles](../docs/agent-profiles.md)
+for the full schema and examples.
+
 ## Included Tools
 
 The container image bundles the following tools so spawned agents have everything they need:

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -483,48 +483,44 @@ class HostDaemon:
         return branch, project, remote_url
 
     def _detect_mcp_servers(self, project_dir, tool):
-        """Detects MCP servers configured for the given tool and project.
+        """Detects MCP servers configured for the given tool.
 
-        For Claude, reads .mcp.json in the project directory and
-        ~/.claude.json for global MCP server configuration.
-        For Gemini, reads ~/.gemini/settings.json.
+        Uses the agent profile's MCP config to find server
+        definitions in project-level and user-level config
+        files. Deduplicates server names across files.
 
         Args:
             project_dir: The project directory path.
-            tool: The agent tool name ('claude', 'gemini', etc.).
+            tool: The agent tool name.
 
         Returns:
             A list of MCP server name strings.
         """
+        profile = self.profiles.get(tool)
+        if not profile or not profile.mcp:
+            return []
+
         servers = []
         try:
-            if tool == "claude":
-                # Project-level .mcp.json
-                if project_dir:
-                    mcp_path = os.path.join(project_dir, ".mcp.json")
-                    if os.path.isfile(mcp_path):
-                        with open(mcp_path, "r", encoding="utf-8") as f:
-                            data = json.load(f)
-                        mcp_servers = data.get("mcpServers", {})
-                        servers.extend(mcp_servers.keys())
+            # Project-level config file
+            if profile.mcp.project_file and project_dir:
+                mcp_path = os.path.join(project_dir, profile.mcp.project_file)
+                if os.path.isfile(mcp_path):
+                    with open(mcp_path, "r", encoding="utf-8") as f:
+                        data = json.load(f)
+                    mcp_servers = data.get("mcpServers", {})
+                    servers.extend(mcp_servers.keys())
 
-                # User-level ~/.claude.json
-                home_claude = os.path.expanduser("~/.claude.json")
-                if os.path.isfile(home_claude):
-                    with open(home_claude, "r", encoding="utf-8") as f:
+            # User-level config files
+            for user_file in profile.mcp.user_files:
+                path = os.path.expanduser(user_file)
+                if os.path.isfile(path):
+                    with open(path, "r", encoding="utf-8") as f:
                         data = json.load(f)
                     mcp_servers = data.get("mcpServers", {})
                     for name in mcp_servers.keys():
                         if name not in servers:
                             servers.append(name)
-
-            elif tool == "gemini":
-                settings_path = os.path.expanduser("~/.gemini/settings.json")
-                if os.path.isfile(settings_path):
-                    with open(settings_path, "r", encoding="utf-8") as f:
-                        data = json.load(f)
-                    mcp_servers = data.get("mcpServers", {})
-                    servers.extend(mcp_servers.keys())
         except Exception as e:
             print(f"MCP detection error for {tool}: {e}")
 

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -302,14 +302,15 @@ class HostDaemon:
             profile: AgentProfile instance.
 
         Returns:
-            Dict with name, display_name, color, and
-            supports_resume fields.
+            Dict with name, display_name, color,
+            supports_resume, and has_model fields.
         """
         return {
             "name": profile.name,
             "display_name": profile.display_name,
             "color": profile.color or "slate",
             "supports_resume": profile.supports_resume,
+            "has_model": bool(profile.telemetry.token_metrics),
         }
 
     def _detect_available_tools(self) -> list:

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -702,35 +702,22 @@ class HostDaemon:
             env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{self.otlp_port}"
             env["OTEL_RESOURCE_ATTRIBUTES"] = f"service.name={agent_id}"
 
-            # Tool-specific OTel enablement
-            env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
-            env["OTEL_METRICS_EXPORTER"] = "otlp"
-            env["OTEL_LOGS_EXPORTER"] = "otlp"
-            env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/json"
-            env["GEMINI_CLI_TELEMETRY_ENABLED"] = "true"
-            env["GEMINI_TELEMETRY_ENABLED"] = "true"
-            # Gemini SDK appends /v1/{traces,logs,metrics} to
-            # this base URL — do NOT include a path suffix.
-            env["GEMINI_TELEMETRY_OTLP_ENDPOINT"] = f"http://127.0.0.1:{self.otlp_port}"
-            env["GEMINI_TELEMETRY_OTLP_PROTOCOL"] = "http"
-            env["GEMINI_TELEMETRY_USE_COLLECTOR"] = "true"
-            env["GEMINI_TELEMETRY_TARGET"] = "local"
+            # Inject profile-specific environment variables.
+            # Values can use {otlp_port} and {agent_id}
+            # placeholders for templating.
+            if profile:
+                for key, value in profile.env.items():
+                    env[key] = str(value).format(
+                        otlp_port=self.otlp_port,
+                        agent_id=agent_id,
+                    )
 
-            # Inject PROMPT_COMMAND for bash sessions to
-            # write structured telemetry (cwd, exit code,
-            # last command) to a sidecar file after each
-            # command.  The daemon reads this periodically
-            # in update_agents_git_info().
-            if tool == "bash":
-                sidecar = f"/tmp/.agent-telemetry-{agent_id}"  # nosec B108
+            # Inject sidecar PROMPT_COMMAND if the profile
+            # defines one (e.g. bash telemetry collection).
+            if profile and profile.sidecar and profile.sidecar.prompt_command:
+                sidecar_path = profile.sidecar.file_pattern.format(agent_id=agent_id)
                 env["PROMPT_COMMAND"] = (
-                    'printf \'{"cwd":"%s",'
-                    '"exit_code":%d,'
-                    '"last_cmd":"%s"}\\n\' '
-                    '"$PWD" "$?" '
-                    '"$(HISTTIMEFORMAT= history 1'
-                    " | sed 's/^[ ]*[0-9]*[ ]*//')\" "
-                    f"> {sidecar}"
+                    f"{profile.sidecar.prompt_command} > {sidecar_path}"
                 )
 
             try:

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -41,10 +41,6 @@ _DEFAULT_PERMISSION_PATTERNS = [
     r"Proceed\?",
 ]
 
-# Compiled patterns — populated by HostDaemon.__init__
-# after merging profile-specific patterns.
-PERMISSION_PATTERNS = []
-
 # Seconds of idle output after a pattern match before
 # the status transitions to waiting_permission.
 PERMISSION_IDLE_SECONDS = 2
@@ -132,11 +128,10 @@ class HostDaemon:
             self._excluded_metrics.update(tel.excluded_metrics)
         # Merge permission patterns from profiles into
         # the default generic patterns.
-        global PERMISSION_PATTERNS  # pylint: disable=global-statement
         all_patterns = list(_DEFAULT_PERMISSION_PATTERNS)
         for prof in self.profiles.values():
             all_patterns.extend(prof.permission_patterns)
-        PERMISSION_PATTERNS = [re.compile(p, re.IGNORECASE) for p in all_patterns]
+        self.permission_patterns = [re.compile(p, re.IGNORECASE) for p in all_patterns]
         self.sio = socketio.AsyncClient()
         self.agents: Dict[str, Dict] = (
             {}
@@ -258,33 +253,38 @@ class HostDaemon:
                 except OSError:
                     pass
 
+    def _scan_projects(self) -> list:
+        """Scans PROJECTS_ROOT for git repositories.
+
+        Synchronous method intended to be called from an
+        executor to avoid blocking the event loop.
+
+        Returns:
+            Sorted list of project relative paths.
+        """
+        projects = []
+        if os.path.exists(self.projects_root):
+            try:
+                for root, dirs, _files in os.walk(self.projects_root):
+                    rel_path = os.path.relpath(root, self.projects_root)
+                    depth = 0 if rel_path == "." else len(rel_path.split(os.sep))
+                    if depth > self.projects_depth:
+                        dirs[:] = []
+                        continue
+                    if ".git" in dirs:
+                        if rel_path != ".":
+                            projects.append(rel_path)
+                        dirs[:] = [d for d in dirs if d != ".git"]
+                projects.sort()
+            except Exception as e:
+                print(f"Error scanning projects root {self.projects_root}: {e}")
+        return projects
+
     async def update_projects_cache(self):
         """Continuously updates the project cache in the background every 60 seconds."""
         loop = asyncio.get_running_loop()
         while self.running:
-
-            def _scan():
-                projects = []
-                if os.path.exists(self.projects_root):
-                    try:
-                        for root, dirs, _files in os.walk(self.projects_root):
-                            rel_path = os.path.relpath(root, self.projects_root)
-                            depth = (
-                                0 if rel_path == "." else len(rel_path.split(os.sep))
-                            )
-                            if depth > self.projects_depth:
-                                dirs[:] = []
-                                continue
-                            if ".git" in dirs:
-                                if rel_path != ".":
-                                    projects.append(rel_path)
-                                dirs[:] = [d for d in dirs if d != ".git"]
-                        projects.sort()
-                    except Exception as e:
-                        print(f"Error scanning projects root {self.projects_root}: {e}")
-                return projects
-
-            new_projects = await loop.run_in_executor(None, _scan)
+            new_projects = await loop.run_in_executor(None, self._scan_projects)
             async with self.projects_lock:
                 self.cached_projects = new_projects
 
@@ -371,27 +371,7 @@ class HostDaemon:
         requests from the UI.
         """
         loop = asyncio.get_running_loop()
-
-        def _scan():
-            projects = []
-            if os.path.exists(self.projects_root):
-                try:
-                    for root, dirs, _files in os.walk(self.projects_root):
-                        rel_path = os.path.relpath(root, self.projects_root)
-                        depth = 0 if rel_path == "." else len(rel_path.split(os.sep))
-                        if depth > self.projects_depth:
-                            dirs[:] = []
-                            continue
-                        if ".git" in dirs:
-                            if rel_path != ".":
-                                projects.append(rel_path)
-                            dirs[:] = [d for d in dirs if d != ".git"]
-                    projects.sort()
-                except Exception as e:
-                    print(f"Error scanning projects root {self.projects_root}: {e}")
-            return projects
-
-        new_projects = await loop.run_in_executor(None, _scan)
+        new_projects = await loop.run_in_executor(None, self._scan_projects)
         async with self.projects_lock:
             self.cached_projects = new_projects
         print(f"Force rescan: found {len(new_projects)} projects.")
@@ -724,12 +704,15 @@ class HostDaemon:
 
             # Inject profile-specific environment variables.
             # Values can use {otlp_port} and {agent_id}
-            # placeholders for templating.
+            # placeholders. Uses .replace() instead of
+            # .format() to avoid KeyError if a value
+            # contains literal curly braces.
             if profile:
                 for key, value in profile.env.items():
-                    env[key] = str(value).format(
-                        otlp_port=self.otlp_port,
-                        agent_id=agent_id,
+                    env[key] = (
+                        str(value)
+                        .replace("{otlp_port}", str(self.otlp_port))
+                        .replace("{agent_id}", agent_id)
                     )
 
             # Inject sidecar PROMPT_COMMAND if the profile
@@ -854,7 +837,7 @@ class HostDaemon:
                         # has been idle for PERMISSION_IDLE_SECONDS.
                         stripped = _ANSI_ESCAPE.sub("", decoded_data)
                         now = time.monotonic()
-                        if any(p.search(stripped) for p in PERMISSION_PATTERNS):
+                        if any(p.search(stripped) for p in self.permission_patterns):
                             info["permission_candidate"] = now
                         # New output clears permission_waiting
                         # since the agent is actively producing

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -308,52 +308,53 @@ class HostDaemon:
 
     def _detect_available_tools(self) -> list:
         """Detects which agent CLI tools are installed and
-        configured on this host.
+        configured on this host using agent profiles.
 
-        Checks for binary availability and basic auth
-        configuration. Bash is always available.
+        For each profile, checks if the binary is present
+        and if the required auth env vars are set. Profiles
+        with always_available=true (e.g. bash) are included
+        unconditionally.
 
         Returns:
-            List of tool name strings (e.g. ["gemini",
-            "claude", "bash"]).
+            List of tool name strings.
         """
-        tools = ["bash"]  # Always available
-
-        # Check Gemini CLI
-        try:
-            subprocess.run(
-                ["gemini", "--version"],
-                capture_output=True,
-                timeout=5,
-                check=False,
-            )
-            # Binary exists — check for API key
-            if os.getenv("GEMINI_API_KEY"):
-                tools.append("gemini")
+        tools = []
+        for name, profile in self.profiles.items():
+            if profile.always_available:
+                tools.append(name)
+                continue
+            # Check if binary exists
+            try:
+                subprocess.run(
+                    [profile.binary, "--version"],
+                    capture_output=True,
+                    timeout=5,
+                    check=False,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                continue
+            # Check auth requirements
+            if not profile.auth.env_vars:
+                tools.append(name)
+                continue
+            if profile.auth.require == "all":
+                if all(os.getenv(v) for v in profile.auth.env_vars):
+                    tools.append(name)
+                else:
+                    print(
+                        f"{profile.display_name} CLI found "
+                        f"but auth not configured — "
+                        f"not advertising."
+                    )
             else:
-                print("Gemini CLI found but GEMINI_API_KEY not set — not advertising.")
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
-
-        # Check Claude Code
-        try:
-            subprocess.run(
-                ["claude", "--version"],
-                capture_output=True,
-                timeout=5,
-                check=False,
-            )
-            # Binary exists — check for auth (API key or
-            # Vertex AI credentials)
-            has_api_key = bool(os.getenv("ANTHROPIC_API_KEY"))
-            has_vertex = bool(os.getenv("CLAUDE_CODE_USE_VERTEX"))
-            if has_api_key or has_vertex:
-                tools.append("claude")
-            else:
-                print("Claude CLI found but no auth configured — not advertising.")
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
-
+                if any(os.getenv(v) for v in profile.auth.env_vars):
+                    tools.append(name)
+                else:
+                    print(
+                        f"{profile.display_name} CLI found "
+                        f"but auth not configured — "
+                        f"not advertising."
+                    )
         print(f"Available tools: {tools}")
         return tools
 

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -27,42 +27,22 @@ from aiohttp import web
 
 from agent.profiles import load_profiles
 
-# Terminal patterns that indicate the agent is waiting for
-# user input.  These are matched against stripped terminal
-# output (ANSI escape sequences removed) to avoid false
-# matches on escape codes.  A match sets a "candidate"
-# flag; the status only transitions to waiting_permission
-# after the agent has been idle (no output) for
-# PERMISSION_IDLE_SECONDS.
-#
-# MAINTAINER NOTE: Update these patterns when Claude Code
-# or Gemini CLI change their permission prompt text or
-# format. Test with actual CLI output to avoid false
-# positives.
-PERMISSION_PATTERNS = [
-    re.compile(p, re.IGNORECASE)
-    for p in [
-        # Generic yes/no prompts (anchored to common
-        # bracket/paren formats)
-        r"\[Y/n\]",
-        r"\[y/N\]",
-        r"\(yes/no\)",
-        r"\(y/n\)",
-        # Claude Code permission prompts
-        r"Do you want to proceed",
-        # Gemini CLI permission prompts
-        r"Allow .+ to run",
-        r"Do you want to allow",
-        # General input prompts (anchored with ?)
-        r"press enter to continue",
-        r"Continue\?",
-        r"Proceed\?",
-        # Claude Code plan mode interactive menus
-        r"\u276f\s+\d+\.",  # ❯ 1. (selection cursor)
-        r"\u2610",  # ☐ (unchecked checkbox)
-        r"Skip interview and plan",  # plan mode menu option
-    ]
+# Default permission patterns — generic prompts that
+# apply to all agent tools. Tool-specific patterns are
+# loaded from agent profiles and merged at daemon startup.
+_DEFAULT_PERMISSION_PATTERNS = [
+    r"\[Y/n\]",
+    r"\[y/N\]",
+    r"\(yes/no\)",
+    r"\(y/n\)",
+    r"press enter to continue",
+    r"Continue\?",
+    r"Proceed\?",
 ]
+
+# Compiled patterns — populated by HostDaemon.__init__
+# after merging profile-specific patterns.
+PERMISSION_PATTERNS = []
 
 # Seconds of idle output after a pattern match before
 # the status transitions to waiting_permission.
@@ -149,6 +129,13 @@ class HostDaemon:
             if tel.runtime_metric and tel.runtime_metric.name:
                 self._runtime_metrics[tel.runtime_metric.name] = tel.runtime_metric.unit
             self._excluded_metrics.update(tel.excluded_metrics)
+        # Merge permission patterns from profiles into
+        # the default generic patterns.
+        global PERMISSION_PATTERNS  # pylint: disable=global-statement
+        all_patterns = list(_DEFAULT_PERMISSION_PATTERNS)
+        for prof in self.profiles.values():
+            all_patterns.extend(prof.permission_patterns)
+        PERMISSION_PATTERNS = [re.compile(p, re.IGNORECASE) for p in all_patterns]
         self.sio = socketio.AsyncClient()
         self.agents: Dict[str, Dict] = (
             {}

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -861,12 +861,16 @@ class HostDaemon:
                 os.close(fd)
             except OSError:
                 pass
-            # Clean up PROMPT_COMMAND sidecar file
-            sidecar = f"/tmp/.agent-telemetry-{agent_id}"  # nosec B108
-            try:
-                os.unlink(sidecar)
-            except OSError:
-                pass
+            # Clean up sidecar telemetry file if the
+            # profile defines one
+            tool_name = self.agents[agent_id].get("tool")
+            profile = self.profiles.get(tool_name)
+            if profile and profile.sidecar:
+                sidecar = profile.sidecar.file_pattern.format(agent_id=agent_id)
+                try:
+                    os.unlink(sidecar)
+                except OSError:
+                    pass
             # Clean up git worktree if one was created
             wt_path = self.agents[agent_id].get("worktree_path")
             wt_branch = self.agents[agent_id].get("worktree_branch")
@@ -1425,35 +1429,27 @@ class HostDaemon:
                         tel["git_remote_url"] = remote_url
                         changed = True
 
-                    # Read PROMPT_COMMAND sidecar file for
-                    # bash sessions to get richer telemetry
-                    # (cwd, exit code, last command).
-                    if info.get("tool") == "bash":
-                        sidecar = f"/tmp/.agent-telemetry-{agent_id}"  # nosec B108
+                    # Read sidecar telemetry file if the
+                    # profile defines one (e.g. bash uses
+                    # PROMPT_COMMAND to write cwd, exit code,
+                    # and last command to a JSON file).
+                    tool_name = info.get("tool")
+                    profile = self.profiles.get(tool_name)
+                    if profile and profile.sidecar:
+                        sidecar = profile.sidecar.file_pattern.format(agent_id=agent_id)
                         try:
                             with open(sidecar, "r", encoding="utf-8") as f:
-                                bash_tel = json.loads(f.read().strip())
-                            bash_cwd = bash_tel.get("cwd")
-                            exit_code = bash_tel.get("exit_code")
-                            last_cmd = bash_tel.get("last_cmd", "")
-                            # Show cwd as the activity display
-                            if bash_cwd and tel.get("current_activity") != bash_cwd:
-                                tel["current_activity"] = bash_cwd
-                                changed = True
-                            # Track last exit code for error
-                            # indication on the card
-                            if exit_code is not None:
-                                if tel.get("last_exit_code") != exit_code:
-                                    tel["last_exit_code"] = exit_code
+                                sc_data = json.loads(f.read().strip())
+                            # Map sidecar fields to telemetry
+                            # using the profile's field mapping
+                            for tel_key, sc_key in profile.sidecar.fields.items():
+                                val = sc_data.get(sc_key)
+                                if val is not None and tel.get(tel_key) != val:
+                                    tel[tel_key] = val
                                     changed = True
-                            # Track last command text
-                            if last_cmd and tel.get("last_cmd") != last_cmd:
-                                tel["last_cmd"] = last_cmd
-                                changed = True
                         except (FileNotFoundError, json.JSONDecodeError):
-                            # Sidecar not yet written or
-                            # partially written — fall back
-                            # to /proc cwd
+                            # Sidecar not yet written —
+                            # fall back to /proc cwd
                             if cwd and tel.get("current_activity") != cwd:
                                 tel["current_activity"] = cwd
                                 changed = True

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -294,6 +294,24 @@ class HostDaemon:
 
             await asyncio.sleep(60)
 
+    def _make_tool_info(self, profile) -> dict:
+        """Builds a tool metadata dict from a profile for
+        the available_tools payload sent to the frontend.
+
+        Args:
+            profile: AgentProfile instance.
+
+        Returns:
+            Dict with name, display_name, color, and
+            supports_resume fields.
+        """
+        return {
+            "name": profile.name,
+            "display_name": profile.display_name,
+            "color": profile.color or "slate",
+            "supports_resume": profile.supports_resume,
+        }
+
     def _detect_available_tools(self) -> list:
         """Detects which agent CLI tools are installed and
         configured on this host using agent profiles.
@@ -304,12 +322,13 @@ class HostDaemon:
         unconditionally.
 
         Returns:
-            List of tool name strings.
+            List of tool info dicts with name,
+            display_name, color, and supports_resume.
         """
         tools = []
-        for name, profile in self.profiles.items():
+        for profile in self.profiles.values():
             if profile.always_available:
-                tools.append(name)
+                tools.append(self._make_tool_info(profile))
                 continue
             # Check if binary exists
             try:
@@ -323,11 +342,11 @@ class HostDaemon:
                 continue
             # Check auth requirements
             if not profile.auth.env_vars:
-                tools.append(name)
+                tools.append(self._make_tool_info(profile))
                 continue
             if profile.auth.require == "all":
                 if all(os.getenv(v) for v in profile.auth.env_vars):
-                    tools.append(name)
+                    tools.append(self._make_tool_info(profile))
                 else:
                     print(
                         f"{profile.display_name} CLI found "
@@ -336,7 +355,7 @@ class HostDaemon:
                     )
             else:
                 if any(os.getenv(v) for v in profile.auth.env_vars):
-                    tools.append(name)
+                    tools.append(self._make_tool_info(profile))
                 else:
                     print(
                         f"{profile.display_name} CLI found "

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -133,6 +133,22 @@ class HostDaemon:
         self.projects_depth = int(os.getenv("PROJECTS_DEPTH", "6"))
         # Load agent profiles from YAML/JSON configs
         self.profiles = load_profiles()
+        # Build OTLP metric lookup tables from profiles
+        # for fast matching in handle_otlp().
+        self._token_metrics: set = set()
+        self._cost_metrics: set = set()
+        self._activity_metrics: set = set()
+        self._runtime_metrics: dict = {}
+        self._excluded_metrics: set = set()
+        for prof in self.profiles.values():
+            tel = prof.telemetry
+            self._token_metrics.update(tel.token_metrics)
+            if tel.cost_metric:
+                self._cost_metrics.add(tel.cost_metric)
+            self._activity_metrics.update(tel.activity_metrics)
+            if tel.runtime_metric and tel.runtime_metric.name:
+                self._runtime_metrics[tel.runtime_metric.name] = tel.runtime_metric.unit
+            self._excluded_metrics.update(tel.excluded_metrics)
         self.sio = socketio.AsyncClient()
         self.agents: Dict[str, Dict] = (
             {}
@@ -1249,37 +1265,22 @@ class HostDaemon:
                                 changed = True
 
                             # Token tracking from tool-specific
-                            # usage counters. These are OTLP
-                            # cumulative Sum metrics — use max()
-                            # not +=. Update metric names here
-                            # if CLIs change their telemetry
-                            # schema.
-                            # Claude: claude_code.token.usage
-                            # Gemini: gemini_cli.token.usage
-                            # Note: Gemini also emits
-                            # gen_ai.client.token.usage with
-                            # identical values — intentionally
-                            # excluded to avoid double-counting.
+                            # Token, cost, activity, and runtime
+                            # metrics are matched against the
+                            # lookup tables built from agent
+                            # profiles at startup. Metric names
+                            # are defined in the profile YAML
+                            # files under agent/profiles/.
                             #
-                            # These are OTLP cumulative Sum
-                            # metrics — each report contains the
-                            # total since process start, NOT a
-                            # delta.  Use max() to take the
-                            # latest value without double-counting.
-                            token_metrics = (
-                                "claude_code.token.usage",
-                                "gemini_cli.token.usage",
-                            )
-                            if name in token_metrics:
+                            # Token metrics are OTLP cumulative
+                            # Sum counters — use max() not +=.
+                            if (
+                                name in self._token_metrics
+                                and name not in self._excluded_metrics
+                            ):
                                 value = dp.get("asInt") or dp.get("asDouble") or 0
                                 if value:
                                     int_value = int(value)
-                                    # Split by token type for
-                                    # granular tracking.
-                                    # Claude: input, output,
-                                    #   cacheRead, cacheCreation
-                                    # Gemini: input, output,
-                                    #   thought, cache, tool
                                     token_type = dp_attrs.get("type", "")
                                     if token_type == "input":
                                         tel["input_tokens"] = max(
@@ -1296,17 +1297,11 @@ class HostDaemon:
                                             tel.get("cache_read_tokens", 0),
                                             int_value,
                                         )
-                                    elif token_type in (
-                                        "cacheCreation",
-                                        "cache",
-                                    ):
+                                    elif token_type in ("cacheCreation", "cache"):
                                         tel["cache_creation_tokens"] = max(
                                             tel.get("cache_creation_tokens", 0),
                                             int_value,
                                         )
-                                    # Recompute total from the
-                                    # per-type counters to stay
-                                    # consistent.
                                     tel["tokens"] = (
                                         tel.get("input_tokens", 0)
                                         + tel.get("output_tokens", 0)
@@ -1315,11 +1310,8 @@ class HostDaemon:
                                     )
                                     changed = True
 
-                            # Cost tracking from Claude Code's
-                            # cost.usage metric (USD).
-                            # Cumulative Sum — use max() to
-                            # avoid double-counting.
-                            if name == "claude_code.cost.usage":
+                            # Cost metrics (cumulative Sum, USD)
+                            if name in self._cost_metrics:
                                 value = dp.get("asDouble") or dp.get("asInt") or 0
                                 if value:
                                     tel["cost_usd"] = max(
@@ -1328,16 +1320,8 @@ class HostDaemon:
                                     )
                                     changed = True
 
-                            # Activity from tool call metrics.
-                            # Gemini: gemini_cli.tool.call.count
-                            # Claude: claude_code.tool.execution
-                            tool_metrics = (
-                                "gemini_cli.tool.call.count",
-                                "gemini_cli.tool.call.latency",
-                                "claude_code.tool.execution",
-                                "claude_code.tool",
-                            )
-                            if name in tool_metrics:
+                            # Activity metrics (tool/function name)
+                            if name in self._activity_metrics:
                                 fn = dp_attrs.get("function_name") or dp_attrs.get(
                                     "tool_name"
                                 )
@@ -1345,19 +1329,15 @@ class HostDaemon:
                                     tel["current_activity"] = fn
                                     changed = True
 
-                            # Run time from CLI-reported metrics.
-                            # Claude: active_time.total (seconds)
-                            # Gemini: agent.duration (ms, end-of
-                            #   session only)
-                            if name == ("claude_code.active_time.total"):
+                            # Runtime duration metrics
+                            if name in self._runtime_metrics:
                                 value = dp.get("asInt") or dp.get("asDouble") or 0
                                 if value:
-                                    tel["run_time_seconds"] = int(value)
-                                    changed = True
-                            elif name == ("gemini_cli.agent.duration"):
-                                value = dp.get("asInt") or dp.get("asDouble") or 0
-                                if value:
-                                    tel["run_time_seconds"] = int(value / 1000)
+                                    unit = self._runtime_metrics[name]
+                                    if unit == "milliseconds":
+                                        tel["run_time_seconds"] = int(value / 1000)
+                                    else:
+                                        tel["run_time_seconds"] = int(value)
                                     changed = True
 
                 if changed:

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -25,6 +25,8 @@ from typing import Dict, Optional
 import socketio
 from aiohttp import web
 
+from agent.profiles import load_profiles
+
 # Terminal patterns that indicate the agent is waiting for
 # user input.  These are matched against stripped terminal
 # output (ANSI escape sequences removed) to avoid false
@@ -129,6 +131,8 @@ class HostDaemon:
         # below PROJECTS_ROOT. Default of 6 covers most GitLab
         # org hierarchies without being unlimited.
         self.projects_depth = int(os.getenv("PROJECTS_DEPTH", "6"))
+        # Load agent profiles from YAML/JSON configs
+        self.profiles = load_profiles()
         self.sio = socketio.AsyncClient()
         self.agents: Dict[str, Dict] = (
             {}
@@ -673,33 +677,17 @@ class HostDaemon:
             "worktree_path": worktree_path,
         }
 
-        # Build command based on session_mode.
-        # For resume mode, wrap in a shell fallback so that if
-        # no previous session exists (e.g. claude --continue
-        # errors with "no conversation found"), the agent
-        # automatically starts a fresh session instead of
-        # exiting.
-        if session_mode == "resume":
-            cmd_map = {
-                "gemini": [
-                    "bash",
-                    "-c",
-                    "gemini --resume latest || gemini",
-                ],
-                "claude": [
-                    "bash",
-                    "-c",
-                    "claude --continue || claude",
-                ],
-                "bash": ["bash"],
-            }
+        # Build command from the agent profile. Resume mode
+        # uses a fallback command if defined, otherwise
+        # falls back to the new-session command.
+        profile = self.profiles.get(tool)
+        if profile:
+            if session_mode == "resume" and profile.commands.resume:
+                cmd = profile.commands.resume
+            else:
+                cmd = profile.commands.new or [tool]
         else:
-            cmd_map = {
-                "gemini": ["gemini"],
-                "claude": ["claude"],
-                "bash": ["bash"],
-            }
-        cmd = cmd_map.get(tool, [tool])
+            cmd = [tool]
 
         pid, fd = pty.fork()
         if pid == 0:  # Child process

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -17,6 +17,7 @@ import signal
 import struct
 import subprocess
 import sys
+import tempfile
 import termios
 import time
 from collections import deque
@@ -715,7 +716,9 @@ class HostDaemon:
             # Inject sidecar PROMPT_COMMAND if the profile
             # defines one (e.g. bash telemetry collection).
             if profile and profile.sidecar and profile.sidecar.prompt_command:
-                sidecar_path = profile.sidecar.file_pattern.format(agent_id=agent_id)
+                sidecar_path = profile.sidecar.file_pattern.format(
+                    agent_id=agent_id, tmpdir=tempfile.gettempdir()
+                )
                 env["PROMPT_COMMAND"] = (
                     f"{profile.sidecar.prompt_command} > {sidecar_path}"
                 )
@@ -866,7 +869,9 @@ class HostDaemon:
             tool_name = self.agents[agent_id].get("tool")
             profile = self.profiles.get(tool_name)
             if profile and profile.sidecar:
-                sidecar = profile.sidecar.file_pattern.format(agent_id=agent_id)
+                sidecar = profile.sidecar.file_pattern.format(
+                    agent_id=agent_id, tmpdir=tempfile.gettempdir()
+                )
                 try:
                     os.unlink(sidecar)
                 except OSError:
@@ -1436,7 +1441,9 @@ class HostDaemon:
                     tool_name = info.get("tool")
                     profile = self.profiles.get(tool_name)
                     if profile and profile.sidecar:
-                        sidecar = profile.sidecar.file_pattern.format(agent_id=agent_id)
+                        sidecar = profile.sidecar.file_pattern.format(
+                            agent_id=agent_id, tmpdir=tempfile.gettempdir()
+                        )
                         try:
                             with open(sidecar, "r", encoding="utf-8") as f:
                                 sc_data = json.loads(f.read().strip())

--- a/agent/profiles.py
+++ b/agent/profiles.py
@@ -67,7 +67,7 @@ class SidecarConfig:
     """
 
     prompt_command: Optional[str] = None
-    file_pattern: str = "/tmp/.agent-telemetry-{agent_id}"
+    file_pattern: str = "{tmpdir}/.agent-telemetry-{agent_id}"
     fields: Dict[str, str] = field(default_factory=dict)
 
 
@@ -160,7 +160,7 @@ def _parse_profile(data: dict) -> AgentProfile:
             prompt_command=sc.get("prompt_command"),
             file_pattern=sc.get(
                 "file_pattern",
-                "/tmp/.agent-telemetry-{agent_id}",
+                "{tmpdir}/.agent-telemetry-{agent_id}",
             ),
             fields=sc.get("fields", {}),
         )

--- a/agent/profiles.py
+++ b/agent/profiles.py
@@ -83,6 +83,7 @@ class AgentProfile:
 
     name: str = ""
     display_name: str = ""
+    color: str = ""
     binary: str = ""
     always_available: bool = False
     commands: CommandConfig = field(default_factory=CommandConfig)
@@ -92,6 +93,14 @@ class AgentProfile:
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     sidecar: Optional[SidecarConfig] = None
     permission_patterns: List[str] = field(default_factory=list)
+
+    @property
+    def supports_resume(self) -> bool:
+        """Whether the tool supports resuming a previous
+        session. True when the resume command is defined
+        and differs from the new-session command.
+        """
+        return bool(self.commands.resume) and self.commands.resume != self.commands.new
 
 
 def _parse_profile(data: dict) -> AgentProfile:
@@ -107,6 +116,7 @@ def _parse_profile(data: dict) -> AgentProfile:
     profile = AgentProfile(
         name=data.get("name", ""),
         display_name=data.get("display_name", ""),
+        color=data.get("color", ""),
         binary=data.get("binary", ""),
         always_available=data.get("always_available", False),
         permission_patterns=data.get("permission_patterns", []),

--- a/agent/profiles.py
+++ b/agent/profiles.py
@@ -1,0 +1,215 @@
+"""Agent profile loader for the Host Daemon.
+
+Loads agent tool profiles from YAML/JSON files in the
+profiles/ directory. Each profile defines how to spawn,
+detect, and monitor a specific agent tool (e.g. Claude
+Code, Gemini CLI, Bash).
+
+Profiles are loaded once at daemon startup and used
+throughout the daemon's lifecycle to drive tool-specific
+behavior without hardcoded if/elif branches.
+"""
+
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import yaml
+
+
+@dataclass
+class CommandConfig:
+    """Spawn command configuration for an agent tool."""
+
+    new: List[str] = field(default_factory=list)
+    resume: List[str] = field(default_factory=list)
+
+
+@dataclass
+class AuthConfig:
+    """Authentication detection configuration."""
+
+    env_vars: List[str] = field(default_factory=list)
+    require: str = "any"
+
+
+@dataclass
+class McpConfig:
+    """MCP server detection configuration."""
+
+    project_file: Optional[str] = None
+    user_files: List[str] = field(default_factory=list)
+
+
+@dataclass
+class RuntimeMetric:
+    """Runtime duration metric configuration."""
+
+    name: str = ""
+    unit: str = "seconds"
+
+
+@dataclass
+class TelemetryConfig:
+    """OTLP telemetry metric mapping configuration."""
+
+    token_metrics: List[str] = field(default_factory=list)
+    cost_metric: Optional[str] = None
+    activity_metrics: List[str] = field(default_factory=list)
+    runtime_metric: Optional[RuntimeMetric] = None
+    excluded_metrics: List[str] = field(default_factory=list)
+
+
+@dataclass
+class SidecarConfig:
+    """Sidecar telemetry configuration (e.g. bash
+    PROMPT_COMMAND).
+    """
+
+    prompt_command: Optional[str] = None
+    file_pattern: str = "/tmp/.agent-telemetry-{agent_id}"
+    fields: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AgentProfile:
+    """Complete profile for an agent tool.
+
+    Defines all tool-specific behavior: how to spawn it,
+    what env vars it needs, where its MCP configs live,
+    what OTLP metrics it emits, how to detect if it's
+    installed, and what permission prompts it uses.
+    """
+
+    name: str = ""
+    display_name: str = ""
+    binary: str = ""
+    always_available: bool = False
+    commands: CommandConfig = field(default_factory=CommandConfig)
+    env: Dict[str, str] = field(default_factory=dict)
+    auth: AuthConfig = field(default_factory=AuthConfig)
+    mcp: Optional[McpConfig] = None
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
+    sidecar: Optional[SidecarConfig] = None
+    permission_patterns: List[str] = field(default_factory=list)
+
+
+def _parse_profile(data: dict) -> AgentProfile:
+    """Parses a raw dict (from YAML/JSON) into an
+    AgentProfile dataclass.
+
+    Args:
+        data: Raw profile dict from yaml.safe_load().
+
+    Returns:
+        Populated AgentProfile instance.
+    """
+    profile = AgentProfile(
+        name=data.get("name", ""),
+        display_name=data.get("display_name", ""),
+        binary=data.get("binary", ""),
+        always_available=data.get("always_available", False),
+        permission_patterns=data.get("permission_patterns", []),
+        env=data.get("env", {}),
+    )
+
+    # Commands
+    cmds = data.get("commands", {})
+    profile.commands = CommandConfig(
+        new=cmds.get("new", []),
+        resume=cmds.get("resume", []),
+    )
+
+    # Auth
+    auth = data.get("auth", {})
+    profile.auth = AuthConfig(
+        env_vars=auth.get("env_vars", []),
+        require=auth.get("require", "any"),
+    )
+
+    # MCP
+    mcp = data.get("mcp")
+    if mcp:
+        profile.mcp = McpConfig(
+            project_file=mcp.get("project_file"),
+            user_files=mcp.get("user_files", []),
+        )
+
+    # Telemetry
+    tel = data.get("telemetry", {})
+    runtime = tel.get("runtime_metric")
+    profile.telemetry = TelemetryConfig(
+        token_metrics=tel.get("token_metrics", []),
+        cost_metric=tel.get("cost_metric"),
+        activity_metrics=tel.get("activity_metrics", []),
+        runtime_metric=(
+            RuntimeMetric(
+                name=runtime.get("name", ""),
+                unit=runtime.get("unit", "seconds"),
+            )
+            if runtime
+            else None
+        ),
+        excluded_metrics=tel.get("excluded_metrics", []),
+    )
+
+    # Sidecar
+    sc = data.get("sidecar")
+    if sc:
+        profile.sidecar = SidecarConfig(
+            prompt_command=sc.get("prompt_command"),
+            file_pattern=sc.get(
+                "file_pattern",
+                "/tmp/.agent-telemetry-{agent_id}",
+            ),
+            fields=sc.get("fields", {}),
+        )
+
+    return profile
+
+
+def load_profiles(
+    directory: str = None,
+) -> Dict[str, AgentProfile]:
+    """Loads all agent profiles from a directory.
+
+    Reads all .yaml, .yml, and .json files from the
+    specified directory and parses them into AgentProfile
+    instances.
+
+    Args:
+        directory: Path to the profiles directory.
+            Defaults to agent/profiles/ relative to this
+            file.
+
+    Returns:
+        Dict mapping profile name to AgentProfile.
+    """
+    if directory is None:
+        directory = os.path.join(os.path.dirname(__file__), "profiles")
+
+    profiles = {}
+    if not os.path.isdir(directory):
+        print(f"Profiles directory not found: {directory}")
+        return profiles
+
+    for filename in sorted(os.listdir(directory)):
+        if not filename.endswith((".yaml", ".yml", ".json")):
+            continue
+        filepath = os.path.join(directory, filename)
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            if not data or not isinstance(data, dict):
+                print(f"Skipping empty profile: {filename}")
+                continue
+            profile = _parse_profile(data)
+            if not profile.name:
+                print(f"Profile missing 'name' field: " f"{filename}")
+                continue
+            profiles[profile.name] = profile
+            print(f"Loaded agent profile: {profile.name} " f"({profile.display_name})")
+        except Exception as e:
+            print(f"Error loading profile {filename}: {e}")
+
+    return profiles

--- a/agent/profiles/bash.yaml
+++ b/agent/profiles/bash.yaml
@@ -1,6 +1,7 @@
 # Bash shell agent profile
 name: bash
 display_name: Bash
+color: slate
 binary: bash
 always_available: true
 

--- a/agent/profiles/bash.yaml
+++ b/agent/profiles/bash.yaml
@@ -15,7 +15,7 @@ sidecar:
     printf '{"cwd":"%s","exit_code":%d,"last_cmd":"%s"}\n'
     "$PWD" "$?"
     "$(HISTTIMEFORMAT= history 1 | sed 's/^[ ]*[0-9]*[ ]*//')"
-  file_pattern: "/tmp/.agent-telemetry-{agent_id}"
+  file_pattern: "{tmpdir}/.agent-telemetry-{agent_id}"
   fields:
     current_activity: cwd
     last_exit_code: exit_code

--- a/agent/profiles/bash.yaml
+++ b/agent/profiles/bash.yaml
@@ -1,0 +1,22 @@
+# Bash shell agent profile
+name: bash
+display_name: Bash
+binary: bash
+always_available: true
+
+commands:
+  new: ["bash"]
+  resume: ["bash"]
+
+# Bash uses a PROMPT_COMMAND sidecar to collect telemetry
+# (cwd, exit code, last command) since it doesn't emit OTLP.
+sidecar:
+  prompt_command: >-
+    printf '{"cwd":"%s","exit_code":%d,"last_cmd":"%s"}\n'
+    "$PWD" "$?"
+    "$(HISTTIMEFORMAT= history 1 | sed 's/^[ ]*[0-9]*[ ]*//')"
+  file_pattern: "/tmp/.agent-telemetry-{agent_id}"
+  fields:
+    current_activity: cwd
+    last_exit_code: exit_code
+    last_cmd: last_cmd

--- a/agent/profiles/claude.yaml
+++ b/agent/profiles/claude.yaml
@@ -1,6 +1,7 @@
 # Claude Code agent profile
 name: claude
 display_name: Claude
+color: purple
 binary: claude
 
 commands:

--- a/agent/profiles/claude.yaml
+++ b/agent/profiles/claude.yaml
@@ -1,0 +1,42 @@
+# Claude Code agent profile
+name: claude
+display_name: Claude
+binary: claude
+
+commands:
+  new: ["claude"]
+  resume: ["bash", "-c", "claude --continue || claude"]
+
+env:
+  CLAUDE_CODE_ENABLE_TELEMETRY: "1"
+  OTEL_METRICS_EXPORTER: "otlp"
+  OTEL_LOGS_EXPORTER: "otlp"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/json"
+
+auth:
+  env_vars:
+    - ANTHROPIC_API_KEY
+    - CLAUDE_CODE_USE_VERTEX
+  require: any
+
+mcp:
+  project_file: .mcp.json
+  user_files:
+    - ~/.claude.json
+
+telemetry:
+  token_metrics:
+    - claude_code.token.usage
+  cost_metric: claude_code.cost.usage
+  activity_metrics:
+    - claude_code.tool.execution
+    - claude_code.tool
+  runtime_metric:
+    name: claude_code.active_time.total
+    unit: seconds
+
+permission_patterns:
+  - "Do you want to proceed"
+  - "\\u276f\\s+\\d+\\."
+  - "\\u2610"
+  - "Skip interview and plan"

--- a/agent/profiles/gemini.yaml
+++ b/agent/profiles/gemini.yaml
@@ -1,6 +1,7 @@
 # Gemini CLI agent profile
 name: gemini
 display_name: Gemini
+color: blue
 binary: gemini
 
 commands:

--- a/agent/profiles/gemini.yaml
+++ b/agent/profiles/gemini.yaml
@@ -1,0 +1,46 @@
+# Gemini CLI agent profile
+name: gemini
+display_name: Gemini
+binary: gemini
+
+commands:
+  new: ["gemini"]
+  resume: ["bash", "-c", "gemini --resume latest || gemini"]
+
+# Gemini uses its own telemetry implementation and does
+# NOT honor OTEL_RESOURCE_ATTRIBUTES. The daemon's
+# _resolve_agent_id() falls back to tool-type matching.
+env:
+  GEMINI_CLI_TELEMETRY_ENABLED: "true"
+  GEMINI_TELEMETRY_ENABLED: "true"
+  GEMINI_TELEMETRY_OTLP_ENDPOINT: "http://127.0.0.1:{otlp_port}"
+  GEMINI_TELEMETRY_OTLP_PROTOCOL: "http"
+  GEMINI_TELEMETRY_USE_COLLECTOR: "true"
+  GEMINI_TELEMETRY_TARGET: "local"
+
+auth:
+  env_vars:
+    - GEMINI_API_KEY
+  require: any
+
+mcp:
+  user_files:
+    - ~/.gemini/settings.json
+
+telemetry:
+  token_metrics:
+    - gemini_cli.token.usage
+  activity_metrics:
+    - gemini_cli.tool.call.count
+    - gemini_cli.tool.call.latency
+  runtime_metric:
+    name: gemini_cli.agent.duration
+    unit: milliseconds
+  # Gemini also emits gen_ai.client.token.usage with
+  # identical values — excluded to avoid double-counting.
+  excluded_metrics:
+    - gen_ai.client.token.usage
+
+permission_patterns:
+  - "Allow .+ to run"
+  - "Do you want to allow"

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,2 +1,3 @@
 python-socketio[asyncio_client]
 aiohttp
+pyyaml

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -534,11 +534,13 @@ class TestAgentProfiles:
         assert info["display_name"] == "Claude"
         assert info["color"] == "purple"
         assert info["supports_resume"] is True
+        assert info["has_model"] is True
 
         bash_info = daemon._make_tool_info(daemon.profiles["bash"])
         assert bash_info["name"] == "bash"
         assert bash_info["color"] == "slate"
         assert bash_info["supports_resume"] is False
+        assert bash_info["has_model"] is False
 
     def test_unknown_profile_returns_empty(self):
         """Loading from empty directory returns no profiles."""

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -489,12 +489,10 @@ class TestAgentProfiles:
 
     def test_profile_permission_patterns_merged(self, daemon):
         """Permission patterns from profiles are merged
-        into the global PERMISSION_PATTERNS."""
-        from agent.host_daemon import PERMISSION_PATTERNS
-
-        assert len(PERMISSION_PATTERNS) > 0
+        into the instance permission_patterns list."""
+        assert len(daemon.permission_patterns) > 0
         # Should include generic defaults
-        patterns_str = [p.pattern for p in PERMISSION_PATTERNS]
+        patterns_str = [p.pattern for p in daemon.permission_patterns]
         assert any("Y/n" in p for p in patterns_str)
         # Should include Claude-specific
         assert any("proceed" in p.lower() for p in patterns_str)

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -422,3 +422,98 @@ class TestDetectMcpServers:
         with patch("os.path.isfile", return_value=False):
             servers = daemon._detect_mcp_servers("/proj", "claude")
         assert servers == []
+
+
+# ── G. Agent Profiles ───────────────────────────────────────
+
+
+class TestAgentProfiles:
+    """Tests for the agent profile loading system."""
+
+    def test_load_bundled_profiles(self):
+        """All three bundled profiles load successfully."""
+        from agent.profiles import load_profiles
+
+        profiles = load_profiles()
+        assert "claude" in profiles
+        assert "gemini" in profiles
+        assert "bash" in profiles
+
+    def test_claude_profile_fields(self):
+        """Claude profile has expected configuration."""
+        from agent.profiles import load_profiles
+
+        profiles = load_profiles()
+        claude = profiles["claude"]
+        assert claude.binary == "claude"
+        assert claude.display_name == "Claude"
+        assert claude.commands.new == ["claude"]
+        assert len(claude.commands.resume) > 0
+        assert len(claude.env) > 0
+        assert "ANTHROPIC_API_KEY" in claude.auth.env_vars
+        assert claude.auth.require == "any"
+        assert claude.mcp is not None
+        assert claude.mcp.project_file == ".mcp.json"
+        assert len(claude.telemetry.token_metrics) > 0
+        assert claude.telemetry.cost_metric is not None
+        assert len(claude.permission_patterns) > 0
+        assert not claude.always_available
+
+    def test_gemini_profile_fields(self):
+        """Gemini profile has expected configuration."""
+        from agent.profiles import load_profiles
+
+        profiles = load_profiles()
+        gemini = profiles["gemini"]
+        assert gemini.binary == "gemini"
+        assert "GEMINI_API_KEY" in gemini.auth.env_vars
+        assert gemini.mcp is not None
+        assert len(gemini.telemetry.token_metrics) > 0
+        assert gemini.telemetry.runtime_metric is not None
+        assert gemini.telemetry.runtime_metric.unit == "milliseconds"
+        assert len(gemini.telemetry.excluded_metrics) > 0
+        assert not gemini.always_available
+
+    def test_bash_profile_fields(self):
+        """Bash profile has sidecar config and always_available."""
+        from agent.profiles import load_profiles
+
+        profiles = load_profiles()
+        bash = profiles["bash"]
+        assert bash.binary == "bash"
+        assert bash.always_available is True
+        assert bash.sidecar is not None
+        assert bash.sidecar.prompt_command is not None
+        assert "agent_id" in bash.sidecar.file_pattern
+        assert "current_activity" in bash.sidecar.fields
+
+    def test_profile_permission_patterns_merged(self, daemon):
+        """Permission patterns from profiles are merged
+        into the global PERMISSION_PATTERNS."""
+        from agent.host_daemon import PERMISSION_PATTERNS
+
+        assert len(PERMISSION_PATTERNS) > 0
+        # Should include generic defaults
+        patterns_str = [p.pattern for p in PERMISSION_PATTERNS]
+        assert any("Y/n" in p for p in patterns_str)
+        # Should include Claude-specific
+        assert any("proceed" in p.lower() for p in patterns_str)
+
+    def test_otlp_lookup_tables_built(self, daemon):
+        """OTLP metric lookup tables are populated from profiles."""
+        assert "claude_code.token.usage" in daemon._token_metrics
+        assert "gemini_cli.token.usage" in daemon._token_metrics
+        assert "claude_code.cost.usage" in daemon._cost_metrics
+        assert "claude_code.active_time.total" in daemon._runtime_metrics
+        assert "gemini_cli.agent.duration" in daemon._runtime_metrics
+        assert "gen_ai.client.token.usage" in daemon._excluded_metrics
+
+    def test_unknown_profile_returns_empty(self):
+        """Loading from empty directory returns no profiles."""
+        import tempfile
+
+        from agent.profiles import load_profiles
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            profiles = load_profiles(tmpdir)
+        assert profiles == {}

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -508,6 +508,40 @@ class TestAgentProfiles:
         assert "gemini_cli.agent.duration" in daemon._runtime_metrics
         assert "gen_ai.client.token.usage" in daemon._excluded_metrics
 
+    def test_supports_resume_property(self):
+        """supports_resume is True when resume differs from
+        new, False when they are the same."""
+        from agent.profiles import load_profiles
+
+        profiles = load_profiles()
+        # Claude and Gemini have distinct resume commands
+        assert profiles["claude"].supports_resume is True
+        assert profiles["gemini"].supports_resume is True
+        # Bash has resume == new == ["bash"]
+        assert profiles["bash"].supports_resume is False
+
+    def test_color_field_loaded(self):
+        """Color field is loaded from profile YAML files."""
+        from agent.profiles import load_profiles
+
+        profiles = load_profiles()
+        assert profiles["claude"].color == "purple"
+        assert profiles["gemini"].color == "blue"
+        assert profiles["bash"].color == "slate"
+
+    def test_make_tool_info(self, daemon):
+        """_make_tool_info builds correct metadata dict."""
+        info = daemon._make_tool_info(daemon.profiles["claude"])
+        assert info["name"] == "claude"
+        assert info["display_name"] == "Claude"
+        assert info["color"] == "purple"
+        assert info["supports_resume"] is True
+
+        bash_info = daemon._make_tool_info(daemon.profiles["bash"])
+        assert bash_info["name"] == "bash"
+        assert bash_info["color"] == "slate"
+        assert bash_info["supports_resume"] is False
+
     def test_unknown_profile_returns_empty(self):
         """Loading from empty directory returns no profiles."""
         import tempfile

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -165,9 +165,10 @@ class AgentSchema(AgentBase):
 
 
 class AgentDetailSchema(AgentSchema):
-    """Extended agent schema that includes the host name."""
+    """Extended agent schema with host name and tools."""
 
     host_name: str
+    available_tools: Optional[list] = None
 
 
 class SpawnRequest(BaseModel):
@@ -320,6 +321,11 @@ def get_agent_details(
 
     host = db.query(models.Host).filter(models.Host.id == db_agent.host_id).first()
     host_name = host.name if host else "unknown"
+    available_tools = (
+        host.last_projects_json.get("available_tools")
+        if host and host.last_projects_json
+        else None
+    )
 
     return AgentDetailSchema(
         id=db_agent.id,
@@ -332,6 +338,7 @@ def get_agent_details(
         started_at=db_agent.started_at,
         ended_at=db_agent.ended_at,
         host_name=host_name,
+        available_tools=available_tools,
     )
 
 

--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -4,6 +4,8 @@ Manages real-time communication between the frontend UI, the
 backend hub, and remote host daemons over the /terminal namespace.
 """
 
+from datetime import datetime, timezone
+
 import socketio
 
 from . import database, models
@@ -46,12 +48,44 @@ async def connect(sid, environ, auth):
         host.status = "online"
         db.commit()
 
+        # Close any stale agents from a previous daemon
+        # session. When a daemon restarts, its in-memory
+        # agent state is gone — any agents still marked
+        # "active" in the DB are unrecoverable.
+        stale_agents = (
+            db.query(models.Agent)
+            .filter(
+                models.Agent.host_id == host.id,
+                models.Agent.status == "active",
+            )
+            .all()
+        )
+        if stale_agents:
+            now = datetime.now(timezone.utc)
+            for agent in stale_agents:
+                agent.status = "closed"
+                agent.ended_at = now
+            db.commit()
+            print(f"Closed {len(stale_agents)} stale agent(s)" f" for host {host.name}")
+
         # Join a room specific to this host's ID so we can send spawn commands to it
         room_name = f"host_{host.id}"
         await sio.enter_room(sid, room_name, namespace="/terminal")
         print(
             f"Host Daemon connected: {host.name} (SID: {sid}) joined room: {room_name}"
         )
+
+        # Notify UI about closed stale agents after
+        # joining the room so the emit goes through.
+        for agent in stale_agents:
+            await sio.emit(
+                "agent_status_update",
+                {
+                    "agent_id": agent.agent_id,
+                    "status": "closed",
+                },
+                namespace="/terminal",
+            )
 
     finally:
         db.close()
@@ -70,12 +104,42 @@ async def disconnect(sid):
                 host = db.query(models.Host).filter(models.Host.id == host_id).first()
                 if host:
                     host.status = "offline"
+
+                    # Close all active agents — the daemon
+                    # process is gone so they can't be
+                    # recovered from this session.
+                    active_agents = (
+                        db.query(models.Agent)
+                        .filter(
+                            models.Agent.host_id == host_id,
+                            models.Agent.status == "active",
+                        )
+                        .all()
+                    )
+                    if active_agents:
+                        now = datetime.now(timezone.utc)
+                        for agent in active_agents:
+                            agent.status = "closed"
+                            agent.ended_at = now
+
                     db.commit()
                     print(
                         f"Host Daemon {host.name}"
                         f" (ID: {host_id}) disconnected"
-                        f" and marked offline."
+                        f" — marked offline, closed"
+                        f" {len(active_agents)} agent(s)."
                     )
+
+                    # Notify UI so agent cards disappear
+                    for agent in active_agents:
+                        await sio.emit(
+                            "agent_status_update",
+                            {
+                                "agent_id": agent.agent_id,
+                                "status": "closed",
+                            },
+                            namespace="/terminal",
+                        )
             finally:
                 db.close()
 
@@ -225,8 +289,6 @@ async def handle_agent_exit(sid, data):
             )
             if db_agent:
                 db_agent.status = "closed"
-                from datetime import datetime, timezone
-
                 db_agent.ended_at = datetime.now(timezone.utc)
                 db.commit()
                 print(f"Agent {agent_id} exited and marked as closed in DB.")

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -1,0 +1,141 @@
+# Agent Profiles
+
+Agent profiles define how the host daemon spawns, detects,
+and monitors each AI coding agent tool. Instead of hardcoded
+logic for specific tools, the daemon reads YAML or JSON
+profile files from the `agent/profiles/` directory at
+startup.
+
+## Bundled Profiles
+
+Three profiles are included out of the box:
+
+| Profile | File | Description |
+|---------|------|-------------|
+| Claude | `agent/profiles/claude.yaml` | Claude Code CLI with OTLP telemetry and MCP detection |
+| Gemini | `agent/profiles/gemini.yaml` | Gemini CLI with custom telemetry endpoints |
+| Bash | `agent/profiles/bash.yaml` | Bash shell with PROMPT_COMMAND sidecar telemetry |
+
+## Creating a Custom Profile
+
+To add support for a new agent tool, create a YAML or JSON
+file in `agent/profiles/`. The daemon loads all `.yaml`,
+`.yml`, and `.json` files from this directory on startup.
+
+### Minimal Profile
+
+```yaml
+name: myagent
+display_name: My Agent
+binary: myagent-cli
+
+commands:
+  new: ["myagent-cli"]
+  resume: ["myagent-cli", "--resume"]
+```
+
+### Full Schema
+
+```yaml
+# Required: unique identifier used in spawn requests
+name: myagent
+
+# Display name shown in logs and UI
+display_name: My Agent
+
+# Binary to check for availability
+binary: myagent-cli
+
+# If true, always listed as available (e.g. bash)
+always_available: false
+
+# Spawn commands
+commands:
+  # Command for new sessions
+  new: ["myagent-cli"]
+  # Command for resume mode (can include fallback chains)
+  resume: ["bash", "-c", "myagent-cli --resume || myagent-cli"]
+
+# Environment variables injected at spawn time.
+# Supports {otlp_port} and {agent_id} placeholders.
+env:
+  MY_AGENT_TELEMETRY: "true"
+  MY_AGENT_OTLP_ENDPOINT: "http://127.0.0.1:{otlp_port}"
+
+# Auth detection for the Spawn button visibility
+auth:
+  # Environment variables to check
+  env_vars:
+    - MY_AGENT_API_KEY
+  # "any" = at least one must be set
+  # "all" = all must be set
+  require: any
+
+# MCP server config file locations
+mcp:
+  # Project-level config (relative to project dir)
+  project_file: .mcp.json
+  # User-level config files (~ expanded)
+  user_files:
+    - ~/.myagent/config.json
+
+# OTLP telemetry metric mappings
+telemetry:
+  # Metric names for token usage tracking
+  token_metrics:
+    - myagent.token.usage
+  # Metric name for cost tracking (USD)
+  cost_metric: myagent.cost.usage
+  # Metric names for tool/function activity
+  activity_metrics:
+    - myagent.tool.execution
+  # Runtime duration metric
+  runtime_metric:
+    name: myagent.active_time
+    unit: seconds  # or "milliseconds"
+  # Metrics to explicitly ignore (avoid double-counting)
+  excluded_metrics:
+    - gen_ai.client.token.usage
+
+# Sidecar telemetry (for tools without OTLP support)
+sidecar:
+  # Shell command injected as PROMPT_COMMAND
+  prompt_command: >-
+    printf '{"cwd":"%s"}\n' "$PWD"
+  # File path pattern ({agent_id} is replaced at runtime)
+  file_pattern: "/tmp/.agent-telemetry-{agent_id}"
+  # Map sidecar JSON keys to telemetry field names
+  fields:
+    current_activity: cwd
+
+# Permission prompt patterns (regex, case-insensitive)
+# These are merged with generic defaults (Y/n, yes/no, etc.)
+permission_patterns:
+  - "Do you want to proceed"
+  - "Allow .+ to run"
+```
+
+## How Profiles Are Used
+
+| Feature | Profile Field | Daemon Method |
+|---------|--------------|---------------|
+| Spawn commands | `commands.new`, `commands.resume` | `spawn_agent()` |
+| Environment vars | `env` | `spawn_agent()` (child process) |
+| Tool detection | `binary`, `auth`, `always_available` | `_detect_available_tools()` |
+| MCP detection | `mcp.project_file`, `mcp.user_files` | `_detect_mcp_servers()` |
+| Token tracking | `telemetry.token_metrics` | `handle_otlp()` |
+| Cost tracking | `telemetry.cost_metric` | `handle_otlp()` |
+| Activity tracking | `telemetry.activity_metrics` | `handle_otlp()` |
+| Runtime tracking | `telemetry.runtime_metric` | `handle_otlp()` |
+| Permission prompts | `permission_patterns` | Terminal output matching |
+| Sidecar telemetry | `sidecar.*` | `update_agents_git_info()` |
+
+## Notes
+
+- The standard OTLP endpoint and resource attributes
+  (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_RESOURCE_ATTRIBUTES`)
+  are always injected by the daemon regardless of profile.
+- Generic permission patterns (Y/n, yes/no, Continue?, etc.)
+  are always active. Profile patterns are merged in addition.
+- Profile changes require a daemon restart to take effect.
+- The daemon logs which profiles were loaded at startup.

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -27,6 +27,7 @@ file in `agent/profiles/`. The daemon loads all `.yaml`,
 ```yaml
 name: myagent
 display_name: My Agent
+color: green
 binary: myagent-cli
 
 commands:
@@ -42,6 +43,11 @@ name: myagent
 
 # Display name shown in logs and UI
 display_name: My Agent
+
+# UI theme color for spawn buttons and badges.
+# Supported keywords: purple, blue, slate, green,
+# red, amber, cyan. Defaults to slate if omitted.
+color: green
 
 # Binary to check for availability
 binary: myagent-cli
@@ -102,8 +108,8 @@ sidecar:
   # Shell command injected as PROMPT_COMMAND
   prompt_command: >-
     printf '{"cwd":"%s"}\n' "$PWD"
-  # File path pattern ({agent_id} is replaced at runtime)
-  file_pattern: "/tmp/.agent-telemetry-{agent_id}"
+  # File path pattern ({tmpdir} and {agent_id} replaced at runtime)
+  file_pattern: "{tmpdir}/.agent-telemetry-{agent_id}"
   # Map sidecar JSON keys to telemetry field names
   fields:
     current_activity: cwd
@@ -117,11 +123,14 @@ permission_patterns:
 
 ## How Profiles Are Used
 
-| Feature | Profile Field | Daemon Method |
-|---------|--------------|---------------|
+| Feature | Profile Field | Used By |
+|---------|--------------|---------|
 | Spawn commands | `commands.new`, `commands.resume` | `spawn_agent()` |
 | Environment vars | `env` | `spawn_agent()` (child process) |
 | Tool detection | `binary`, `auth`, `always_available` | `_detect_available_tools()` |
+| Spawn button label | `display_name` | HostCard, SpawnModal, Terminal header |
+| Spawn button color | `color` | HostCard buttons, Terminal badge |
+| Resume mode toggle | `commands.resume` vs `commands.new` | SpawnModal (derived) |
 | MCP detection | `mcp.project_file`, `mcp.user_files` | `_detect_mcp_servers()` |
 | Token tracking | `telemetry.token_metrics` | `handle_otlp()` |
 | Cost tracking | `telemetry.cost_metric` | `handle_otlp()` |
@@ -129,6 +138,96 @@ permission_patterns:
 | Runtime tracking | `telemetry.runtime_metric` | `handle_otlp()` |
 | Permission prompts | `permission_patterns` | Terminal output matching |
 | Sidecar telemetry | `sidecar.*` | `update_agents_git_info()` |
+| Companion buttons | `name`, `display_name` | Terminal companion bar |
+
+## Resume Mode
+
+The SpawnModal shows a "Resume Session" toggle when a tool
+supports resuming previous sessions. This is **derived
+automatically** from the `commands` configuration — no
+separate flag is needed:
+
+- **Supports resume**: `commands.resume` is defined AND
+  differs from `commands.new` (e.g. Claude, Gemini).
+- **No resume**: `commands.resume` is empty, undefined, or
+  identical to `commands.new` (e.g. Bash where both are
+  `["bash"]`).
+
+## Adding a New Agent Tool
+
+To add support for a completely new agent tool (e.g.
+Aider, Codex, Cursor), follow these steps:
+
+### 1. Create the Profile
+
+Create a YAML file in `agent/profiles/`:
+
+```yaml
+# agent/profiles/aider.yaml
+name: aider
+display_name: Aider
+color: green
+binary: aider
+
+commands:
+  new: ["aider"]
+  resume: ["aider"]
+
+auth:
+  env_vars:
+    - OPENAI_API_KEY
+  require: any
+```
+
+### 2. Install the Binary in the Container
+
+Update `agent/Containerfile` to install the tool. The
+method depends on the tool's distribution:
+
+```dockerfile
+# Example: pip-distributed tool
+RUN pip3 install --no-cache-dir aider-chat
+
+# Example: npm-distributed tool
+RUN npm install -g @some-org/some-agent
+
+# Example: standalone binary
+RUN curl -sSL https://example.com/agent \
+    -o /usr/local/bin/agent \
+    && chmod +x /usr/local/bin/agent
+```
+
+### 3. Mount Credentials (if needed)
+
+If the tool needs config files or credentials from the
+host, add volume mounts to your container run command or
+compose file. Document the required mounts in
+`agent/README.md`.
+
+### 4. Set Auth Environment Variables
+
+If the profile has `auth.env_vars`, pass the required
+environment variables to the container:
+
+```bash
+-e OPENAI_API_KEY="sk-..."   # podman run
+Environment=OPENAI_API_KEY=sk-...   # systemd quadlet
+```
+
+### 5. Rebuild and Deploy
+
+```bash
+cd agent/
+podman build -t agent-dashboard-daemon -f Containerfile .
+```
+
+Restart the daemon. The new tool will automatically:
+- Appear as a spawn button with the configured color
+- Show in the TUI tool selector
+- Be available as a companion in terminal views
+- Have its resume toggle derived from the commands config
+
+No frontend or backend code changes are required.
 
 ## Notes
 
@@ -139,3 +238,6 @@ permission_patterns:
   are always active. Profile patterns are merged in addition.
 - Profile changes require a daemon restart to take effect.
 - The daemon logs which profiles were loaded at startup.
+- Supported color keywords: `purple`, `blue`, `slate`,
+  `green`, `red`, `amber`, `cyan`. Unknown keywords fall
+  back to `slate`.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,6 +8,29 @@ const api = axios.create({
   withCredentials: true, // Required for session cookies from OIDC
 });
 
+/** Tool metadata reported by the daemon from profiles. */
+export interface ToolInfo {
+  name: string;
+  display_name: string;
+  color?: string;
+  supports_resume?: boolean;
+}
+
+/**
+ * Normalizes a tool entry from available_tools into a
+ * ToolInfo object. Handles both enriched dicts (new
+ * daemons) and bare name strings (older daemons).
+ */
+export function normalizeToolInfo(tool: string | ToolInfo): ToolInfo {
+  if (typeof tool === 'string') {
+    return {
+      name: tool,
+      display_name: tool.charAt(0).toUpperCase() + tool.slice(1),
+    };
+  }
+  return tool;
+}
+
 export interface Host {
   id: number;
   name: string;
@@ -16,7 +39,7 @@ export interface Host {
   projects?: {
     projects_root: string;
     available_projects: string[];
-    available_tools?: string[];
+    available_tools?: (string | ToolInfo)[];
   };
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -128,6 +128,7 @@ export const updateTaskDescription = async (
 
 export interface AgentDetail extends Agent {
   host_name: string;
+  available_tools?: (string | ToolInfo)[];
 }
 
 export const getAgentDetails = async (

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -14,6 +14,7 @@ export interface ToolInfo {
   display_name: string;
   color?: string;
   supports_resume?: boolean;
+  has_model?: boolean;
 }
 
 /**

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -8,6 +8,7 @@ import {
   getVersion,
 } from '../api';
 import type { Host, Agent, VersionInfo } from '../api';
+import { normalizeToolInfo } from '../api';
 import { Cpu, Activity } from 'lucide-react';
 import { io } from 'socket.io-client';
 import LogoSvg from './LogoSvg';
@@ -308,27 +309,36 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
         </div>
       </section>
 
-      {activeSpawn && (
-        <SpawnModal
-          host={hosts.find((h) => h.id === activeSpawn.hostId)!}
-          tool={activeSpawn.tool}
-          activeAgents={activeAgents.filter(
-            (a) => a.host_id === activeSpawn.hostId,
-          )}
-          onClose={() => setActiveSpawn(null)}
-          onSpawn={(dir, task, sessionMode, useWorktree) =>
-            handleSpawn(
-              activeSpawn.hostId,
-              activeSpawn.tool,
-              dir,
-              task,
-              sessionMode,
-              useWorktree,
-            )
-          }
-          onRefresh={requestProjects}
-        />
-      )}
+      {activeSpawn &&
+        (() => {
+          const spawnHost = hosts.find((h) => h.id === activeSpawn.hostId);
+          const toolInfo = spawnHost?.projects?.available_tools
+            ?.map(normalizeToolInfo)
+            .find((t) => t.name === activeSpawn.tool);
+          return (
+            <SpawnModal
+              host={spawnHost!}
+              tool={activeSpawn.tool}
+              displayName={toolInfo?.display_name}
+              supportsResume={toolInfo?.supports_resume}
+              activeAgents={activeAgents.filter(
+                (a) => a.host_id === activeSpawn.hostId,
+              )}
+              onClose={() => setActiveSpawn(null)}
+              onSpawn={(dir, task, sessionMode, useWorktree) =>
+                handleSpawn(
+                  activeSpawn.hostId,
+                  activeSpawn.tool,
+                  dir,
+                  task,
+                  sessionMode,
+                  useWorktree,
+                )
+              }
+              onRefresh={requestProjects}
+            />
+          );
+        })()}
     </div>
   );
 };

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -12,8 +12,15 @@ import {
   RefreshCw,
 } from 'lucide-react';
 import '@xterm/xterm/css/xterm.css';
-import type { AgentDetail, Agent } from '../api';
-import { getAgentDetails, getCompanions, spawnAgent, stopAgent } from '../api';
+import type { AgentDetail, Agent, ToolInfo } from '../api';
+import {
+  getAgentDetails,
+  getCompanions,
+  spawnAgent,
+  stopAgent,
+  normalizeToolInfo,
+} from '../api';
+import { getToolColorsByKeyword } from './dashboard/utils';
 
 interface TerminalProps {
   agentId: string;
@@ -121,7 +128,7 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
           agentDetail.telemetry?.project_dir;
         const newAgent = await spawnAgent(
           agentDetail.host_id,
-          agentDetail.tool_name || 'gemini',
+          agentDetail.tool_name || 'bash',
           projectDir,
           agentDetail.telemetry?.task_description,
           'resume',
@@ -167,9 +174,7 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
   const handleOpenCompanion = useCallback(
     async (targetTool: string) => {
       // Check existing companions for matching tool
-      const existing = companions.find(
-        (c) => categorize(c.tool_name) === targetTool,
-      );
+      const existing = companions.find((c) => c.tool_name === targetTool);
       if (existing) {
         openTerminalWindow(existing.agent_id);
         return;
@@ -493,9 +498,27 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
   const gitRemoteUrl = agentDetail?.telemetry?.git_remote_url;
   const worktreePath = agentDetail?.telemetry?.worktree_path;
 
+  // Build tool info from available_tools on this host.
+  const allTools: ToolInfo[] = (agentDetail?.available_tools || []).map(
+    normalizeToolInfo,
+  );
+
+  // Prefer display_name from profile metadata over the
+  // hardcoded label map for the tool badge and title.
+  const profileInfo = allTools.find((t) => t.name === agentDetail?.tool_name);
+  const toolLabel = profileInfo?.display_name || TOOL_LABELS[category];
+  const toolBadgeColor = profileInfo?.color
+    ? getToolColorsByKeyword(profileInfo.color).solid
+    : TOOL_COLORS[category];
+
+  // Companion buttons: all other tools on this host.
+  const companionButtons = allTools
+    .filter((t) => t.name !== agentDetail?.tool_name)
+    .map((t) => ({ label: t.display_name, tool: t.name, color: t.color }));
+
   // Update browser window title with host / project / branch
   useEffect(() => {
-    const parts = [TOOL_LABELS[category]];
+    const parts = [toolLabel];
     if (hostName) parts.push(hostName);
     if (gitProject) parts.push(gitProject);
     if (gitBranch) parts.push(gitBranch);
@@ -504,16 +527,7 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
     return () => {
       document.title = 'Agent Dashboard';
     };
-  }, [category, hostName, gitProject, gitBranch, worktreePath]);
-
-  // Build companion buttons based on current tool type
-  const companionButtons: { label: string; tool: ToolCategory }[] = [];
-  if (category === 'bash') {
-    companionButtons.push({ label: 'Gemini', tool: 'gemini' });
-    companionButtons.push({ label: 'Claude', tool: 'claude' });
-  } else if (category === 'gemini' || category === 'claude') {
-    companionButtons.push({ label: 'Bash', tool: 'bash' });
-  }
+  }, [toolLabel, hostName, gitProject, gitBranch, worktreePath]);
 
   return (
     <div className="flex-1 flex flex-col h-full w-full bg-black overflow-hidden">
@@ -523,9 +537,9 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
         <div className="flex items-center gap-3 min-w-0">
           {/* Tool badge */}
           <span
-            className={`${TOOL_COLORS[category]} text-white text-[10px] font-bold uppercase px-2 py-0.5 rounded tracking-wider shrink-0`}
+            className={`${toolBadgeColor} text-white text-[10px] font-bold uppercase px-2 py-0.5 rounded tracking-wider shrink-0`}
           >
-            {TOOL_LABELS[category]}
+            {toolLabel}
           </span>
 
           {/* Host / project / branch */}
@@ -585,9 +599,7 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
         {/* Right side: companion + close buttons */}
         <div className="flex items-center gap-2 shrink-0">
           {companionButtons.map((btn) => {
-            const existing = companions.find(
-              (c) => categorize(c.tool_name) === btn.tool,
-            );
+            const existing = companions.find((c) => c.tool_name === btn.tool);
             return (
               <button
                 key={btn.tool}

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -152,52 +152,44 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
               </span>
             )}
           </div>
-          {ctxTokens > 0 && (
-            <div className="mt-1.5">
-              <div className="flex justify-between items-center mb-1">
-                <span className="text-[9px] text-slate-500 uppercase font-bold tracking-tight">
-                  Context
-                </span>
-                <span className="text-[10px] text-slate-400 font-mono">
-                  {ctxTokens.toLocaleString()} /{' '}
-                  {contextMax >= 1000000
-                    ? `${(contextMax / 1000000).toFixed(1).replace('.0', '')}M`
-                    : `${(contextMax / 1000).toFixed(0)}k`}
-                </span>
-              </div>
-              <div className="w-full h-2.5 bg-slate-700 rounded-full overflow-hidden">
-                <div
-                  className={`h-full rounded-full transition-all duration-500 ${getProgressColor(tokenPct)}`}
-                  style={{
-                    width: `${Math.max(tokenPct, 1)}%`,
-                  }}
-                />
-              </div>
-            </div>
-          )}
-          {/* Cost + token breakdown — hidden until data arrives */}
-          {!!(tel.input_tokens || tel.output_tokens || displayCost) && (
-            <div className="flex justify-between items-center mt-2 pt-1.5 border-t border-slate-700/30">
-              <span
-                className="text-[10px] text-slate-400 font-mono"
-                title={costSource}
-              >
-                {formatCost(displayCost)}
+          <div className="mt-1.5">
+            <div className="flex justify-between items-center mb-1">
+              <span className="text-[9px] text-slate-500 uppercase font-bold tracking-tight">
+                Context
               </span>
-              {!!(tel.input_tokens || tel.output_tokens) && (
-                <span className="text-[10px] text-slate-400 font-mono">
-                  {tel.input_tokens
-                    ? formatTokenCount(tel.input_tokens) + ' in'
-                    : ''}
-                  {tel.input_tokens && tel.output_tokens ? ' / ' : ''}
-                  {tel.output_tokens
-                    ? formatTokenCount(tel.output_tokens) + ' out'
-                    : ''}
-                </span>
-              )}
+              <span className="text-[10px] text-slate-400 font-mono">
+                {ctxTokens ? ctxTokens.toLocaleString() : '—'} /{' '}
+                {contextMax >= 1000000
+                  ? `${(contextMax / 1000000).toFixed(1).replace('.0', '')}M`
+                  : `${(contextMax / 1000).toFixed(0)}k`}
+              </span>
             </div>
-          )}
-          {/* Cache token breakdown */}
+            <div className="w-full h-2.5 bg-slate-700 rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${getProgressColor(tokenPct)}`}
+                style={{
+                  width: `${Math.max(tokenPct, 1)}%`,
+                }}
+              />
+            </div>
+          </div>
+          <div className="flex justify-between items-center mt-2 pt-1.5 border-t border-slate-700/30">
+            <span
+              className="text-[10px] text-slate-400 font-mono"
+              title={costSource}
+            >
+              {formatCost(displayCost)}
+            </span>
+            <span className="text-[10px] text-slate-400 font-mono">
+              {tel.input_tokens
+                ? formatTokenCount(tel.input_tokens) + ' in'
+                : ''}
+              {tel.input_tokens && tel.output_tokens ? ' / ' : ''}
+              {tel.output_tokens
+                ? formatTokenCount(tel.output_tokens) + ' out'
+                : ''}
+            </span>
+          </div>
           {!!(tel.cache_read_tokens || tel.cache_creation_tokens) && (
             <p className="text-[9px] text-slate-500 font-mono text-right mt-0.5">
               {tel.cache_read_tokens

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -82,7 +82,7 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
             <span
               className={`text-[10px] px-2 py-0.5 rounded font-bold uppercase border ${getToolColors(agent.tool_name).badge}`}
             >
-              {agent.tool_name || 'gemini'}
+              {agent.tool_name || 'agent'}
             </span>
             {tel.git_remote_url ? (
               <a
@@ -131,7 +131,7 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
         <StatusIndicator status={tel.agent_status} />
       </div>
 
-      {agent.tool_name !== 'bash' && (
+      {tel.model && (
         <div className="my-2 border-t border-slate-700/50 pt-2">
           <div className="flex items-center gap-1">
             <p className="text-[11px] text-slate-300 font-mono truncate">
@@ -205,7 +205,7 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
           agentId={agent.agent_id}
           description={tel.task_description || ''}
         />
-        {agent.tool_name === 'bash' ? (
+        {tel.last_cmd !== undefined || tel.last_exit_code !== undefined ? (
           <>
             {tel.current_activity && (
               <p

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -140,11 +140,11 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
         <StatusIndicator status={tel.agent_status} />
       </div>
 
-      {tel.model && tel.model !== 'detecting...' && (
+      {(toolInfo?.has_model ?? (tel.model && tel.model !== 'detecting...')) && (
         <div className="my-2 border-t border-slate-700/50 pt-2">
           <div className="flex items-center gap-1">
             <p className="text-[11px] text-slate-300 font-mono truncate">
-              {tel.model || '...'}
+              {tel.model && tel.model !== 'detecting...' ? tel.model : '...'}
             </p>
             {tel.model && !isModelRecognized(tel.model) && (
               <span title="Unrecognized model — context window and pricing may be inaccurate">

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -63,7 +63,6 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
   const tokenPct = ctxTokens
     ? Math.min((ctxTokens / contextMax) * 100, 100)
     : 0;
-  const totalTokens = tel.tokens || 0;
   // Use OTLP-reported cost (Claude) or estimate from
   // pricing tables (Gemini / other).
   const displayCost =
@@ -174,7 +173,7 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
               />
             </div>
           </div>
-          {/* Total tokens + cost row */}
+          {/* Cost + token breakdown row */}
           <div className="flex justify-between items-center mt-2 pt-1.5 border-t border-slate-700/30">
             <span
               className="text-[10px] text-slate-400 font-mono"
@@ -182,24 +181,30 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
             >
               {formatCost(displayCost)}
             </span>
-            <span className="text-[10px] text-slate-400 font-mono">
-              {totalTokens
-                ? `${formatTokenCount(totalTokens)} tokens`
-                : '0 tokens'}
-            </span>
+            {(tel.input_tokens || tel.output_tokens) && (
+              <span className="text-[10px] text-slate-400 font-mono">
+                {tel.input_tokens
+                  ? formatTokenCount(tel.input_tokens) + ' in'
+                  : ''}
+                {tel.input_tokens && tel.output_tokens ? ' / ' : ''}
+                {tel.output_tokens
+                  ? formatTokenCount(tel.output_tokens) + ' out'
+                  : ''}
+              </span>
+            )}
           </div>
-          {/* Input/output breakdown */}
-          {tel.input_tokens || tel.output_tokens ? (
+          {/* Cache token breakdown */}
+          {(tel.cache_read_tokens || tel.cache_creation_tokens) && (
             <p className="text-[9px] text-slate-500 font-mono text-right mt-0.5">
-              {tel.input_tokens
-                ? formatTokenCount(tel.input_tokens) + ' in'
+              {tel.cache_read_tokens
+                ? formatTokenCount(tel.cache_read_tokens) + ' cache read'
                 : ''}
-              {tel.input_tokens && tel.output_tokens ? ' / ' : ''}
-              {tel.output_tokens
-                ? formatTokenCount(tel.output_tokens) + ' out'
+              {tel.cache_read_tokens && tel.cache_creation_tokens ? ' / ' : ''}
+              {tel.cache_creation_tokens
+                ? formatTokenCount(tel.cache_creation_tokens) + ' cache write'
                 : ''}
             </p>
-          ) : null}
+          )}
         </div>
       )}
 

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -11,10 +11,11 @@ import {
   GitFork,
   TriangleAlert,
 } from 'lucide-react';
-import type { Agent } from '../../api';
+import type { Agent, ToolInfo } from '../../api';
 import {
   getContextWindow,
   getToolColors,
+  getToolColorsByKeyword,
   getProgressColor,
   formatDuration,
   estimateCost,
@@ -28,6 +29,8 @@ import EditableTaskDescription from './EditableTaskDescription';
 /** Props for the AgentSessionCard component. */
 interface AgentSessionCardProps {
   agent: Agent;
+  /** Tool metadata from the host's available_tools list. */
+  availableTools?: ToolInfo[];
   onAttach: (agentId: string) => void;
   onStop: (agentId: string) => void;
 }
@@ -39,10 +42,17 @@ interface AgentSessionCardProps {
  */
 const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
   agent,
+  availableTools,
   onAttach,
   onStop,
 }) => {
   const tel = agent.telemetry || {};
+  // Prefer profile color from available_tools metadata,
+  // falling back to name-based inference.
+  const toolInfo = availableTools?.find((t) => t.name === agent.tool_name);
+  const toolColors = toolInfo?.color
+    ? getToolColorsByKeyword(toolInfo.color)
+    : getToolColors(agent.tool_name);
   // Use context_tokens (per-call input tokens) for the
   // progress bar — reflects current context window usage
   // after compression. Do NOT fall back to cumulative
@@ -74,13 +84,13 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
 
   return (
     <div
-      className={`bg-slate-800 rounded-2xl p-4 border border-slate-700 ${getToolColors(agent.tool_name).border} transition-all shadow-lg flex flex-col h-full group`}
+      className={`bg-slate-800 rounded-2xl p-4 border border-slate-700 ${toolColors.border} transition-all shadow-lg flex flex-col h-full group`}
     >
       <div className="flex justify-between items-start mb-2">
         <div className="overflow-hidden">
           <div className="flex gap-2 items-center">
             <span
-              className={`text-[10px] px-2 py-0.5 rounded font-bold uppercase border ${getToolColors(agent.tool_name).badge}`}
+              className={`text-[10px] px-2 py-0.5 rounded font-bold uppercase border ${toolColors.badge}`}
             >
               {agent.tool_name || 'agent'}
             </span>

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -152,47 +152,51 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
               </span>
             )}
           </div>
-          <div className="mt-1.5">
-            <div className="flex justify-between items-center mb-1">
-              <span className="text-[9px] text-slate-500 uppercase font-bold tracking-tight">
-                Context
-              </span>
-              <span className="text-[10px] text-slate-400 font-mono">
-                {ctxTokens ? ctxTokens.toLocaleString() : '0'} /{' '}
-                {contextMax >= 1000000
-                  ? `${(contextMax / 1000000).toFixed(1).replace('.0', '')}M`
-                  : `${(contextMax / 1000).toFixed(0)}k`}
-              </span>
+          {ctxTokens > 0 && (
+            <div className="mt-1.5">
+              <div className="flex justify-between items-center mb-1">
+                <span className="text-[9px] text-slate-500 uppercase font-bold tracking-tight">
+                  Context
+                </span>
+                <span className="text-[10px] text-slate-400 font-mono">
+                  {ctxTokens.toLocaleString()} /{' '}
+                  {contextMax >= 1000000
+                    ? `${(contextMax / 1000000).toFixed(1).replace('.0', '')}M`
+                    : `${(contextMax / 1000).toFixed(0)}k`}
+                </span>
+              </div>
+              <div className="w-full h-2.5 bg-slate-700 rounded-full overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all duration-500 ${getProgressColor(tokenPct)}`}
+                  style={{
+                    width: `${Math.max(tokenPct, 1)}%`,
+                  }}
+                />
+              </div>
             </div>
-            <div className="w-full h-2.5 bg-slate-700 rounded-full overflow-hidden">
-              <div
-                className={`h-full rounded-full transition-all duration-500 ${getProgressColor(tokenPct)}`}
-                style={{
-                  width: `${Math.max(tokenPct, 1)}%`,
-                }}
-              />
-            </div>
-          </div>
-          {/* Cost + token breakdown row */}
-          <div className="flex justify-between items-center mt-2 pt-1.5 border-t border-slate-700/30">
-            <span
-              className="text-[10px] text-slate-400 font-mono"
-              title={costSource}
-            >
-              {formatCost(displayCost)}
-            </span>
-            {(tel.input_tokens || tel.output_tokens) && (
-              <span className="text-[10px] text-slate-400 font-mono">
-                {tel.input_tokens
-                  ? formatTokenCount(tel.input_tokens) + ' in'
-                  : ''}
-                {tel.input_tokens && tel.output_tokens ? ' / ' : ''}
-                {tel.output_tokens
-                  ? formatTokenCount(tel.output_tokens) + ' out'
-                  : ''}
+          )}
+          {/* Cost + token breakdown — hidden until data arrives */}
+          {(tel.input_tokens || tel.output_tokens || displayCost) && (
+            <div className="flex justify-between items-center mt-2 pt-1.5 border-t border-slate-700/30">
+              <span
+                className="text-[10px] text-slate-400 font-mono"
+                title={costSource}
+              >
+                {formatCost(displayCost)}
               </span>
-            )}
-          </div>
+              {(tel.input_tokens || tel.output_tokens) && (
+                <span className="text-[10px] text-slate-400 font-mono">
+                  {tel.input_tokens
+                    ? formatTokenCount(tel.input_tokens) + ' in'
+                    : ''}
+                  {tel.input_tokens && tel.output_tokens ? ' / ' : ''}
+                  {tel.output_tokens
+                    ? formatTokenCount(tel.output_tokens) + ' out'
+                    : ''}
+                </span>
+              )}
+            </div>
+          )}
           {/* Cache token breakdown */}
           {(tel.cache_read_tokens || tel.cache_creation_tokens) && (
             <p className="text-[9px] text-slate-500 font-mono text-right mt-0.5">

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -176,7 +176,7 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
             </div>
           )}
           {/* Cost + token breakdown — hidden until data arrives */}
-          {(tel.input_tokens || tel.output_tokens || displayCost) && (
+          {!!(tel.input_tokens || tel.output_tokens || displayCost) && (
             <div className="flex justify-between items-center mt-2 pt-1.5 border-t border-slate-700/30">
               <span
                 className="text-[10px] text-slate-400 font-mono"
@@ -184,7 +184,7 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
               >
                 {formatCost(displayCost)}
               </span>
-              {(tel.input_tokens || tel.output_tokens) && (
+              {!!(tel.input_tokens || tel.output_tokens) && (
                 <span className="text-[10px] text-slate-400 font-mono">
                   {tel.input_tokens
                     ? formatTokenCount(tel.input_tokens) + ' in'
@@ -198,7 +198,7 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
             </div>
           )}
           {/* Cache token breakdown */}
-          {(tel.cache_read_tokens || tel.cache_creation_tokens) && (
+          {!!(tel.cache_read_tokens || tel.cache_creation_tokens) && (
             <p className="text-[9px] text-slate-500 font-mono text-right mt-0.5">
               {tel.cache_read_tokens
                 ? formatTokenCount(tel.cache_read_tokens) + ' cache read'

--- a/frontend/src/components/dashboard/AgentSessionCard.tsx
+++ b/frontend/src/components/dashboard/AgentSessionCard.tsx
@@ -141,7 +141,7 @@ const AgentSessionCard: React.FC<AgentSessionCardProps> = ({
         <StatusIndicator status={tel.agent_status} />
       </div>
 
-      {tel.model && (
+      {tel.model && tel.model !== 'detecting...' && (
         <div className="my-2 border-t border-slate-700/50 pt-2">
           <div className="flex items-center gap-1">
             <p className="text-[11px] text-slate-300 font-mono truncate">

--- a/frontend/src/components/dashboard/HostCard.tsx
+++ b/frontend/src/components/dashboard/HostCard.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Server, Wifi, WifiOff, PlusCircle, Trash2 } from 'lucide-react';
 import type { Host, Agent } from '../../api';
+import { normalizeToolInfo } from '../../api';
 import AgentSessionCard from './AgentSessionCard';
+import { getToolColorsByKeyword } from './utils';
 
 /** Props for the HostCard component. */
 interface HostCardProps {
@@ -28,11 +30,9 @@ const HostCard: React.FC<HostCardProps> = ({
   onDeleteHost,
 }) => {
   const isOnline = host.status === 'online';
-  const availableTools = host.projects?.available_tools || [
-    'gemini',
-    'claude',
-    'bash',
-  ];
+  const availableTools = (host.projects?.available_tools || []).map(
+    normalizeToolInfo,
+  );
 
   return (
     <div
@@ -66,45 +66,23 @@ const HostCard: React.FC<HostCardProps> = ({
 
         {/* Row 2: Spawn + Delete buttons */}
         <div className="flex items-center gap-2 mt-2">
-          {availableTools.includes('gemini') && (
-            <button
-              onClick={() => onSpawnClick(host.id, 'gemini')}
-              disabled={!isOnline}
-              className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
-                isOnline
-                  ? 'bg-blue-500/20 hover:bg-blue-500/40 text-blue-400 border-blue-500/30 cursor-pointer'
-                  : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
-              }`}
-            >
-              <PlusCircle size={14} /> Spawn Gemini
-            </button>
-          )}
-          {availableTools.includes('claude') && (
-            <button
-              onClick={() => onSpawnClick(host.id, 'claude')}
-              disabled={!isOnline}
-              className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
-                isOnline
-                  ? 'bg-purple-500/20 hover:bg-purple-500/40 text-purple-400 border-purple-500/30 cursor-pointer'
-                  : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
-              }`}
-            >
-              <PlusCircle size={14} /> Spawn Claude
-            </button>
-          )}
-          {availableTools.includes('bash') && (
-            <button
-              onClick={() => onSpawnClick(host.id, 'bash')}
-              disabled={!isOnline}
-              className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
-                isOnline
-                  ? 'bg-slate-700 hover:bg-slate-600 text-slate-300 border-slate-600 cursor-pointer'
-                  : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
-              }`}
-            >
-              <PlusCircle size={14} /> Spawn Bash
-            </button>
-          )}
+          {availableTools.map((tool) => {
+            const colors = getToolColorsByKeyword(tool.color);
+            return (
+              <button
+                key={tool.name}
+                onClick={() => onSpawnClick(host.id, tool.name)}
+                disabled={!isOnline}
+                className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
+                  isOnline
+                    ? `${colors.button} ${colors.buttonHover} cursor-pointer`
+                    : 'bg-slate-700/50 text-slate-500 border-slate-700 cursor-not-allowed'
+                }`}
+              >
+                <PlusCircle size={14} /> Spawn {tool.display_name}
+              </button>
+            );
+          })}
           <button
             onClick={() => onDeleteHost(host.id)}
             className="text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 bg-red-500/20 hover:bg-red-500/40 text-red-400 border-red-500/30 cursor-pointer ml-auto"

--- a/frontend/src/components/dashboard/HostCard.tsx
+++ b/frontend/src/components/dashboard/HostCard.tsx
@@ -100,6 +100,7 @@ const HostCard: React.FC<HostCardProps> = ({
             <AgentSessionCard
               key={agent.id}
               agent={agent}
+              availableTools={availableTools}
               onAttach={onAttach}
               onStop={onStop}
             />

--- a/frontend/src/components/dashboard/SpawnModal.tsx
+++ b/frontend/src/components/dashboard/SpawnModal.tsx
@@ -13,6 +13,10 @@ import type { Agent, Host } from '../../api';
 export interface SpawnModalProps {
   host: Host;
   tool: string;
+  /** Human-readable tool name from the profile. */
+  displayName?: string;
+  /** Whether the tool supports resuming sessions. */
+  supportsResume?: boolean;
   /** Active agents on this host, used to compute the
    *  smart default for the worktree isolation toggle. */
   activeAgents?: Agent[];
@@ -35,6 +39,8 @@ export interface SpawnModalProps {
 const SpawnModal: React.FC<SpawnModalProps> = ({
   host,
   tool,
+  displayName,
+  supportsResume: supportsResumeProp,
   activeAgents = [],
   onClose,
   onSpawn,
@@ -48,7 +54,7 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
   const [task, setTask] = useState('');
   const [resumeSession, setResumeSession] = useState(true);
   const [useWorktree, setUseWorktree] = useState(false);
-  const showResume = tool === 'claude' || tool === 'gemini';
+  const showResume = supportsResumeProp ?? false;
 
   // Auto-select first project when list arrives
   useEffect(() => {
@@ -83,7 +89,7 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
         <div className="flex justify-between items-center p-6 border-b border-slate-700 bg-slate-800/50">
           <h3 className="text-xl font-bold text-slate-50 flex items-center gap-2">
             <PlusCircle size={24} className="text-accent" />
-            Spawn {tool.toUpperCase()}
+            Spawn {displayName || tool.toUpperCase()}
           </h3>
           <button
             onClick={onClose}

--- a/frontend/src/components/dashboard/utils.ts
+++ b/frontend/src/components/dashboard/utils.ts
@@ -152,29 +152,93 @@ export const isModelRecognized = (model?: string): boolean => {
   return false;
 };
 
+/** Tailwind class sets for each color keyword. */
+export interface ToolColorSet {
+  badge: string;
+  border: string;
+  button: string;
+  buttonHover: string;
+  solid: string;
+}
+
 /**
- * Returns Tailwind color classes for agent tool type badges.
- * Gemini = blue, Claude = purple, Bash = slate.
+ * Maps profile color keywords to Tailwind class sets.
+ * All class names are fully spelled out (no interpolation)
+ * so Tailwind's content scanner can find them.
+ */
+export const TOOL_COLOR_MAP: Record<string, ToolColorSet> = {
+  purple: {
+    badge: 'bg-purple-500/20 text-purple-400 border-purple-500/20',
+    border: 'hover:border-purple-500/50',
+    button: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
+    buttonHover: 'hover:bg-purple-500/40',
+    solid: 'bg-purple-500',
+  },
+  blue: {
+    badge: 'bg-blue-500/20 text-blue-400 border-blue-500/20',
+    border: 'hover:border-blue-500/50',
+    button: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+    buttonHover: 'hover:bg-blue-500/40',
+    solid: 'bg-blue-500',
+  },
+  slate: {
+    badge: 'bg-slate-500/20 text-slate-300 border-slate-500/20',
+    border: 'hover:border-slate-500/50',
+    button: 'bg-slate-700 text-slate-300 border-slate-600',
+    buttonHover: 'hover:bg-slate-600',
+    solid: 'bg-slate-500',
+  },
+  green: {
+    badge: 'bg-green-500/20 text-green-400 border-green-500/20',
+    border: 'hover:border-green-500/50',
+    button: 'bg-green-500/20 text-green-400 border-green-500/30',
+    buttonHover: 'hover:bg-green-500/40',
+    solid: 'bg-green-500',
+  },
+  red: {
+    badge: 'bg-red-500/20 text-red-400 border-red-500/20',
+    border: 'hover:border-red-500/50',
+    button: 'bg-red-500/20 text-red-400 border-red-500/30',
+    buttonHover: 'hover:bg-red-500/40',
+    solid: 'bg-red-500',
+  },
+  amber: {
+    badge: 'bg-amber-500/20 text-amber-400 border-amber-500/20',
+    border: 'hover:border-amber-500/50',
+    button: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
+    buttonHover: 'hover:bg-amber-500/40',
+    solid: 'bg-amber-500',
+  },
+  cyan: {
+    badge: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/20',
+    border: 'hover:border-cyan-500/50',
+    button: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
+    buttonHover: 'hover:bg-cyan-500/40',
+    solid: 'bg-cyan-500',
+  },
+};
+
+/**
+ * Returns Tailwind color classes for a profile color
+ * keyword. Falls back to slate for unknown keywords.
+ */
+export const getToolColorsByKeyword = (color?: string): ToolColorSet => {
+  return TOOL_COLOR_MAP[color || 'slate'] || TOOL_COLOR_MAP['slate'];
+};
+
+/**
+ * Returns Tailwind color classes for agent tool type
+ * badges. Infers color from tool name when no color
+ * keyword is available (e.g. from agent records that
+ * only store tool_name as a string).
  */
 export const getToolColors = (toolName?: string) => {
   const t = (toolName || '').toLowerCase();
-  if (t.includes('claude')) {
-    return {
-      badge: 'bg-purple-500/20 text-purple-400 border-purple-500/20',
-      border: 'hover:border-purple-500/50',
-    };
-  }
+  if (t.includes('claude')) return getToolColorsByKeyword('purple');
   if (t.includes('bash') || t.includes('shell')) {
-    return {
-      badge: 'bg-slate-500/20 text-slate-300 border-slate-500/20',
-      border: 'hover:border-slate-500/50',
-    };
+    return getToolColorsByKeyword('slate');
   }
-  // Default: gemini / blue
-  return {
-    badge: 'bg-blue-500/20 text-blue-400 border-blue-500/20',
-    border: 'hover:border-blue-500/50',
-  };
+  return getToolColorsByKeyword('blue');
 };
 
 /**

--- a/tui/screens/spawn.py
+++ b/tui/screens/spawn.py
@@ -74,16 +74,13 @@ class SpawnScreen(Screen):
                 prompt="Select a host",
             )
 
-            # Tool selector
+            # Tool selector — populated dynamically when
+            # a host is selected based on its available_tools.
             yield Label("Tool", classes="field-label")
             yield Select(
-                [
-                    ("Claude", "claude"),
-                    ("Gemini", "gemini"),
-                    ("Bash", "bash"),
-                ],
+                [],
                 id="tool-select",
-                prompt="Select a tool",
+                prompt="Select host first",
             )
 
             # Project selector
@@ -138,9 +135,27 @@ class SpawnScreen(Screen):
                     break
             if host and host.get("projects"):
                 projects = host["projects"].get("available_projects", [])
+                raw_tools = host["projects"].get("available_tools", [])
             else:
                 projects = []
+                raw_tools = []
             self._projects = projects
+
+            # Update tool selector from host's profiles
+            tool_select = self.query_one("#tool-select", Select)
+            if raw_tools and isinstance(raw_tools[0], dict):
+                tool_options = [
+                    (t.get("display_name", t["name"]), t["name"]) for t in raw_tools
+                ]
+            elif raw_tools and isinstance(raw_tools[0], str):
+                tool_options = [(t.capitalize(), t) for t in raw_tools]
+            else:
+                tool_options = [
+                    ("Claude", "claude"),
+                    ("Gemini", "gemini"),
+                    ("Bash", "bash"),
+                ]
+            tool_select.set_options(tool_options)
 
             # Update project selector
             project_select = self.query_one("#project-select", Select)


### PR DESCRIPTION
## Summary

Extracts all hardcoded tool-specific logic from the host daemon and frontend into YAML/JSON configuration profiles. Adding support for a new agent tool (e.g. Aider, Codex) now requires only dropping a YAML file into `agent/profiles/` and installing the binary in the container — no Python or TypeScript changes needed.

### Daemon (Phases 1-10)
- **Profile loader** (`agent/profiles.py`): `AgentProfile` dataclass hierarchy with `CommandConfig`, `AuthConfig`, `McpConfig`, `TelemetryConfig`, `SidecarConfig`, plus `color` field and `supports_resume` derived property
- **Bundled profiles**: `claude.yaml`, `gemini.yaml`, `bash.yaml` with full configuration
- **Generalized daemon** (`agent/host_daemon.py`): Command construction, env vars, MCP detection, OTLP telemetry extraction, tool detection, permission patterns, and sidecar telemetry all driven by profiles instead of if/elif branches
- **Enriched `available_tools` payload**: Now sends `List[dict]` with `name`, `display_name`, `color`, `supports_resume`, `has_model` instead of bare name strings

### Frontend (Phase 11)
- **Dynamic spawn buttons** (`HostCard.tsx`): Single `.map()` loop over `available_tools` replaces three hardcoded button blocks — colors and labels from profile metadata
- **Profile-driven resume toggle** (`SpawnModal.tsx`): `supports_resume` from profile metadata replaces hardcoded `tool === 'claude' || tool === 'gemini'`
- **Data-driven agent cards** (`AgentSessionCard.tsx`): Model/sidecar sections render based on `has_model` profile flag and telemetry content; profile color threaded via `availableTools` prop from HostCard
- **Stable card layout**: Model-capable cards always render context bar, cost, and token sections (with "—" placeholders) so card heights are consistent before and after telemetry arrives
- **Dynamic companion buttons** (`Terminal.tsx`): Built from `available_tools` on the agent's host instead of hardcoded pairings
- **Color utilities** (`utils.ts`): `TOOL_COLOR_MAP` maps color keywords to Tailwind class sets; `getToolColorsByKeyword()` for profile-driven lookup
- **Type safety** (`api.ts`): `ToolInfo` interface and `normalizeToolInfo()` helper handle both enriched dicts and bare strings for backward compatibility

### TUI
- **Dynamic tool selector** (`tui/screens/spawn.py`): Tool options populated from host's `available_tools` when a host is selected

### Backend
- **Agent detail enrichment** (`main.py`): `AgentDetailSchema` now includes `available_tools` from the host, enabling dynamic companion buttons in the terminal view
- **Stale agent cleanup** (`socket.py`): Close all active agents for a host on both connect (daemon restart) and disconnect (daemon goes offline), with UI notification so ghost cards disappear immediately (#54)

### Infrastructure
- **Containerfile**: Preserves `agent` Python package structure for correct imports (`python3 -m agent.host_daemon`)
- **Portable temp paths**: Uses `{tmpdir}` template + `tempfile.gettempdir()` instead of hardcoded `/tmp`

### Code Review Refactoring
- **Remove global state**: `PERMISSION_PATTERNS` moved from module-level global to `self.permission_patterns` instance variable
- **Fix DRY violation**: Duplicated `_scan()` inner function extracted to `_scan_projects()` method
- **Defensive string substitution**: `.format()` replaced with `.replace()` chains for profile env var injection to avoid KeyError on literal curly braces
- **Profile colors in agent cards**: `availableTools` prop threaded from HostCard to AgentSessionCard for profile-driven badge colors

### Bug Fixes
- **Bash model/context display**: Fixed regression where bash cards showed "detecting..." model and empty context bar (`has_model` profile flag drives section visibility)
- **Token display clarity**: Replaced misleading aggregate "total tokens" with clear in/out breakdown plus cache read/write line when present
- **Stray "0" rendering**: Fixed React short-circuit gotcha where `{0 && <Component />}` rendered literal "0" text for zero-valued telemetry fields
- **Stable card heights**: Context bar and cost/token rows always rendered for model-capable tools (with "—" placeholders) instead of hidden until data arrives
- **Ghost agent cards** (#54): Stale agent records cleaned up on daemon connect/disconnect so ghost cards no longer persist after daemon restarts

### Tests & Documentation
- 55 unit tests (10 new) covering profile loading, field validation, `supports_resume`, `color`, `has_model`, `_make_tool_info`, permission pattern merging, OTLP lookup tables
- Full profile schema reference in `docs/agent-profiles.md` with "Adding a New Agent Tool" walkthrough including Containerfile and credential setup

## Test plan
- [ ] Rebuild and deploy all three containers (daemon, backend, frontend)
- [ ] Verify spawn buttons appear dynamically with correct colors
- [ ] Verify resume toggle shows only for tools with distinct resume commands
- [ ] Verify companion buttons in terminal show all other available tools
- [ ] Verify model-capable agent cards show consistent height from spawn (placeholders fill in as telemetry arrives)
- [ ] Verify bash cards do NOT show model/context section
- [ ] Verify token display shows in/out with optional cache line (no misleading total)
- [ ] Verify no stray "0" characters on cards pending telemetry
- [ ] Verify TUI spawn screen shows dynamic tool list per host
- [ ] Verify stale agent cards disappear when daemon disconnects or reconnects
- [ ] Delete a profile YAML → verify its button disappears on next daemon restart
- [ ] All 55 unit tests pass
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)