### PR TITLE
Fix daemon crash on tool detection OSError

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -339,7 +339,7 @@ class HostDaemon:
                     timeout=5,
                     check=False,
                 )
-            except (FileNotFoundError, subprocess.TimeoutExpired):
+            except (OSError, subprocess.TimeoutExpired):
                 continue
             # Check auth requirements
             if not profile.auth.env_vars:


### PR DESCRIPTION
## Summary

- Widen exception catch in `_detect_available_tools()` from `FileNotFoundError` to `OSError`
- `ENOEXEC` (Exec format error) is an `OSError` subclass, not `FileNotFoundError` — it was propagating uncaught through `asyncio.gather()` and crashing the entire daemon
- This was observed in production: a Claude session ran for 34 minutes, then the periodic tool detection cycle hit an exec format error on the `claude --version` check, killing the daemon and all running agents

## Root cause

The `claude` binary is a Node.js shim installed via npm. Under certain conditions (memory pressure, corrupted shim, npm update in progress), the shim can fail with `ENOEXEC` instead of running normally. The tool detection runs every 60 seconds, so even an intermittent failure would eventually crash the daemon.

## Test plan
- [ ] All 45 existing daemon tests pass
- [ ] Daemon survives a tool binary that returns ENOEXEC
- [ ] Existing tool detection behavior unchanged for normal binaries

Addresses #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)