### PR TITLE
Fix session persistence across daemon restarts

### DIFF
--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -48,44 +48,12 @@ async def connect(sid, environ, auth):
         host.status = "online"
         db.commit()
 
-        # Close any stale agents from a previous daemon
-        # session. When a daemon restarts, its in-memory
-        # agent state is gone — any agents still marked
-        # "active" in the DB are unrecoverable.
-        stale_agents = (
-            db.query(models.Agent)
-            .filter(
-                models.Agent.host_id == host.id,
-                models.Agent.status == "active",
-            )
-            .all()
-        )
-        if stale_agents:
-            now = datetime.now(timezone.utc)
-            for agent in stale_agents:
-                agent.status = "closed"
-                agent.ended_at = now
-            db.commit()
-            print(f"Closed {len(stale_agents)} stale agent(s)" f" for host {host.name}")
-
         # Join a room specific to this host's ID so we can send spawn commands to it
         room_name = f"host_{host.id}"
         await sio.enter_room(sid, room_name, namespace="/terminal")
         print(
             f"Host Daemon connected: {host.name} (SID: {sid}) joined room: {room_name}"
         )
-
-        # Notify UI about closed stale agents after
-        # joining the room so the emit goes through.
-        for agent in stale_agents:
-            await sio.emit(
-                "agent_status_update",
-                {
-                    "agent_id": agent.agent_id,
-                    "status": "closed",
-                },
-                namespace="/terminal",
-            )
 
     finally:
         db.close()
@@ -104,42 +72,12 @@ async def disconnect(sid):
                 host = db.query(models.Host).filter(models.Host.id == host_id).first()
                 if host:
                     host.status = "offline"
-
-                    # Close all active agents — the daemon
-                    # process is gone so they can't be
-                    # recovered from this session.
-                    active_agents = (
-                        db.query(models.Agent)
-                        .filter(
-                            models.Agent.host_id == host_id,
-                            models.Agent.status == "active",
-                        )
-                        .all()
-                    )
-                    if active_agents:
-                        now = datetime.now(timezone.utc)
-                        for agent in active_agents:
-                            agent.status = "closed"
-                            agent.ended_at = now
-
                     db.commit()
                     print(
                         f"Host Daemon {host.name}"
                         f" (ID: {host_id}) disconnected"
-                        f" — marked offline, closed"
-                        f" {len(active_agents)} agent(s)."
+                        f" and marked offline."
                     )
-
-                    # Notify UI so agent cards disappear
-                    for agent in active_agents:
-                        await sio.emit(
-                            "agent_status_update",
-                            {
-                                "agent_id": agent.agent_id,
-                                "status": "closed",
-                            },
-                            namespace="/terminal",
-                        )
             finally:
                 db.close()
 


### PR DESCRIPTION
## Summary
- Removes aggressive stale-agent cleanup from Socket.IO `connect` and `disconnect` handlers that was introduced in #50
- Agent session records now persist across daemon restarts, restoring the original design where the dashboard transparently resumes sessions on user reconnect
- Without this fix, all agent cards disappear from the dashboard whenever the daemon container is rebuilt or restarted

## Root cause
The `connect` handler marked all "active" agents as "closed" when a daemon reconnected, and the `disconnect` handler did the same on daemon disconnect. This was intended to clean up unrecoverable pty sessions, but it broke the transparent resume flow — agent records should stay "active" so the UI continues to display them, and the daemon spawns a new resumed session when a user attaches.

## Test plan
- [x] All 25 backend tests pass
- [x] `black` formatting verified
- [ ] Rebuild and restart daemon container — verify agent cards remain on the dashboard
- [ ] Click an existing agent card after daemon restart — verify session resumes transparently

🤖 Generated with [Claude Code](https://claude.com/claude-code)