### PR TITLE
Support multiple PROJECTS_ROOT directories with searchable project selector

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -37,9 +37,9 @@ The container image bundles the following tools so spawned agents have everythin
 The daemon relies on the following environment variables:
 - `HOST_TOKEN`: (Required) The pre-shared token for this host, registered with the Hub.
 - `DASHBOARD_URL`: (Optional) The URL of the central Dashboard Backend. Defaults to `http://localhost:8000`.
-- `PROJECTS_ROOT`: (Optional) Root directory to scan for project repositories. Defaults to `/git`.
+- `PROJECTS_ROOT`: (Optional) Root directory (or colon-separated list of directories) to scan for project repositories. Defaults to `/git`. Example: `PROJECTS_ROOT=/git:/workspace:/data/repos`.
 - `OTLP_PORT`: (Optional) Port for the local OTLP HTTP telemetry receiver. Defaults to `4318`. Set to a different value when running multiple daemons on the same host with `Network=host`.
-- `PROJECTS_DEPTH`: (Optional) Maximum directory depth to scan for git repositories below `PROJECTS_ROOT`. Defaults to `6`.
+- `PROJECTS_DEPTH`: (Optional) Maximum directory depth to scan for git repositories below each `PROJECTS_ROOT` entry. Defaults to `6`.
 
 ### Tool-Specific Configuration
 

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -706,7 +706,11 @@ class HostDaemon:
             f"mode: {session_mode} in {full_path}"
         )
 
-        branch, project, remote_url = self.get_git_info(full_path)
+        # Get git info from the original project directory
+        # (not the worktree) so the card shows the real
+        # project name and remote URL initially.
+        git_info_path = original_project_dir or full_path
+        branch, project, remote_url = self.get_git_info(git_info_path)
         mcp_servers = self._detect_mcp_servers(original_project_dir, tool)
         telemetry = {
             "project_dir": original_project_dir,
@@ -1478,9 +1482,20 @@ class HostDaemon:
                     pid = info["pid"]
                     if not pid:
                         continue
-                    # Try to read the cwd of the child process
+                    # Try to read the cwd of the child process.
+                    # For worktree agents, use the original
+                    # project dir for project name and remote
+                    # URL so the card doesn't show the worktree
+                    # directory name.
                     cwd = os.readlink(f"/proc/{pid}/cwd")
+                    orig = info.get("original_project_dir")
                     branch, project, remote_url = self.get_git_info(cwd)
+                    if orig and orig != cwd:
+                        _, orig_project, orig_url = self.get_git_info(orig)
+                        if orig_project:
+                            project = orig_project
+                        if orig_url:
+                            remote_url = orig_url
 
                     tel = info["telemetry"]
                     changed = False

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -100,13 +100,19 @@ class HostDaemon:
     def __init__(self, server_url: str, host_token: str):
         self.server_url = server_url
         self.host_token = host_token
-        self.projects_root = os.getenv("PROJECTS_ROOT", "/git")
+        # Parse PROJECTS_ROOT as a colon-separated list of
+        # directories to scan for git repositories. A single
+        # path (no colon) works as before.
+        roots_str = os.getenv("PROJECTS_ROOT", "/git")
+        self.projects_roots = [r.strip() for r in roots_str.split(":") if r.strip()]
+        # First root used as default for backward compat
+        self.projects_root = self.projects_roots[0]
         # OTLP receiver port — configurable to allow multiple
         # daemons on the same host via Network=host
         self.otlp_port = int(os.getenv("OTLP_PORT", "4318"))
         # Maximum directory depth to scan for git repositories
-        # below PROJECTS_ROOT. Default of 6 covers most GitLab
-        # org hierarchies without being unlimited.
+        # below each PROJECTS_ROOT entry. Default of 6 covers
+        # most GitLab org hierarchies without being unlimited.
         self.projects_depth = int(os.getenv("PROJECTS_DEPTH", "6"))
         # Load agent profiles from YAML/JSON configs
         self.profiles = load_profiles()
@@ -266,30 +272,33 @@ class HostDaemon:
                     pass
 
     def _scan_projects(self) -> list:
-        """Scans PROJECTS_ROOT for git repositories.
+        """Scans all PROJECTS_ROOT directories for git repos.
 
         Synchronous method intended to be called from an
-        executor to avoid blocking the event loop.
+        executor to avoid blocking the event loop. Iterates
+        over all configured roots and returns absolute paths.
 
         Returns:
-            Sorted list of project relative paths.
+            Sorted list of absolute project paths.
         """
         projects = []
-        if os.path.exists(self.projects_root):
+        for scan_root in self.projects_roots:
+            if not os.path.exists(scan_root):
+                continue
             try:
-                for root, dirs, _files in os.walk(self.projects_root):
-                    rel_path = os.path.relpath(root, self.projects_root)
+                for dirpath, dirs, _files in os.walk(scan_root):
+                    rel_path = os.path.relpath(dirpath, scan_root)
                     depth = 0 if rel_path == "." else len(rel_path.split(os.sep))
                     if depth > self.projects_depth:
                         dirs[:] = []
                         continue
                     if ".git" in dirs:
                         if rel_path != ".":
-                            projects.append(rel_path)
+                            projects.append(os.path.join(scan_root, rel_path))
                         dirs[:] = [d for d in dirs if d != ".git"]
-                projects.sort()
             except Exception as e:
-                print(f"Error scanning projects root {self.projects_root}: {e}")
+                print(f"Error scanning projects root {scan_root}: {e}")
+        projects.sort()
         return projects
 
     async def update_projects_cache(self):
@@ -308,6 +317,24 @@ class HostDaemon:
                 print(f"Project cache update failed: {e}")
 
             await asyncio.sleep(60)
+
+    def _find_project_root(self, project_path: str) -> str:
+        """Finds which projects root contains a path.
+
+        Checks each configured root to see if the path
+        starts with it. Falls back to the first root if
+        no match is found.
+
+        Args:
+            project_path: Absolute path to a project.
+
+        Returns:
+            The matching root directory path.
+        """
+        for root in self.projects_roots:
+            if project_path.startswith(root + "/") or project_path == root:
+                return root
+        return self.projects_roots[0]
 
     def _make_tool_info(self, profile) -> dict:
         """Builds a tool metadata dict from a profile for
@@ -406,7 +433,7 @@ class HostDaemon:
             await self.sio.emit(
                 "host_telemetry",
                 {
-                    "projects_root": self.projects_root,
+                    "projects_root": self.projects_roots,
                     "available_projects": projects,
                     "available_tools": tools,
                 },
@@ -582,18 +609,20 @@ class HostDaemon:
             full_path = os.path.abspath(full_path)
 
         # Create a git worktree for isolation if requested.
-        # The worktree is stored under PROJECTS_ROOT/.agent-worktrees/
-        # to keep the original repo clean.  MCP detection and
-        # companion matching use the original project_dir.
+        # The worktree is stored under the project's root
+        # directory in .agent-worktrees/ to keep the original
+        # repo clean. MCP detection and companion matching
+        # use the original project_dir.
         original_project_dir = full_path
         worktree_path = None
         worktree_branch = None
         if use_worktree and full_path:
             try:
-                project_name = os.path.relpath(full_path, self.projects_root)
+                project_root = self._find_project_root(full_path)
+                project_name = os.path.relpath(full_path, project_root)
                 short_id = agent_id[:8]
                 worktree_dir = os.path.join(
-                    self.projects_root,
+                    project_root,
                     ".agent-worktrees",
                     project_name,
                     f"agent-{short_id}",
@@ -642,8 +671,15 @@ class HostDaemon:
         # worktree). Set worktree_path so the UI shows the
         # worktree indicator, and resolve the original
         # project_dir for MCP detection and companion matching.
-        worktree_marker = os.path.join(self.projects_root, ".agent-worktrees")
-        if not worktree_path and full_path and full_path.startswith(worktree_marker):
+        # Check all roots for worktree markers
+        in_worktree = False
+        if not worktree_path and full_path:
+            for rt in self.projects_roots:
+                marker = os.path.join(rt, ".agent-worktrees")
+                if full_path.startswith(marker):
+                    in_worktree = True
+                    break
+        if in_worktree:
             worktree_path = full_path
             # Resolve original project_dir from the worktree's
             # git configuration.

--- a/agent/profiles/claude.yaml
+++ b/agent/profiles/claude.yaml
@@ -55,6 +55,9 @@ provisioning:
     - host: "~/.claude"
       container: "/root/.claude"
       mode: rw
+    - host: "~/.claude.json"
+      container: "/root/.claude.json"
+      mode: ro
     - host: "~/.config/gcloud"
       container: "/root/.config/gcloud"
       mode: ro

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -11,6 +11,7 @@ F. _detect_mcp_servers
 """
 
 import json
+import os
 import subprocess
 from unittest.mock import patch, mock_open
 
@@ -575,3 +576,83 @@ class TestAgentProfiles:
         with tempfile.TemporaryDirectory() as tmpdir:
             profiles = load_profiles(tmpdir)
         assert profiles == {}
+
+
+# ── H. Multi-Root Projects ─────────────────────────────
+
+
+class TestMultiRoot:
+    """Tests for multi-root PROJECTS_ROOT support."""
+
+    def test_single_root_parsing(self):
+        """Single PROJECTS_ROOT parses as one-element list."""
+        with patch.dict(os.environ, {"PROJECTS_ROOT": "/git"}):
+            d = HostDaemon("http://dummy:8000", "dummy")
+            assert d.projects_roots == ["/git"]
+            assert d.projects_root == "/git"
+
+    def test_multi_root_parsing(self):
+        """Colon-separated PROJECTS_ROOT parses as list."""
+        with patch.dict(
+            os.environ,
+            {"PROJECTS_ROOT": "/git:/workspace:/data/repos"},
+        ):
+            d = HostDaemon("http://dummy:8000", "dummy")
+            assert d.projects_roots == [
+                "/git",
+                "/workspace",
+                "/data/repos",
+            ]
+            assert d.projects_root == "/git"
+
+    def test_multi_root_strips_whitespace(self):
+        """Whitespace around roots is stripped."""
+        with patch.dict(
+            os.environ,
+            {"PROJECTS_ROOT": " /git : /workspace "},
+        ):
+            d = HostDaemon("http://dummy:8000", "dummy")
+            assert d.projects_roots == ["/git", "/workspace"]
+
+    def test_multi_root_ignores_empty(self):
+        """Empty entries from trailing colons are ignored."""
+        with patch.dict(
+            os.environ,
+            {"PROJECTS_ROOT": "/git::/workspace:"},
+        ):
+            d = HostDaemon("http://dummy:8000", "dummy")
+            assert d.projects_roots == ["/git", "/workspace"]
+
+    def test_find_project_root(self):
+        """_find_project_root returns the matching root."""
+        with patch.dict(
+            os.environ,
+            {"PROJECTS_ROOT": "/git:/workspace"},
+        ):
+            d = HostDaemon("http://dummy:8000", "dummy")
+            assert d._find_project_root("/git/org/proj") == "/git"
+            assert d._find_project_root("/workspace/myapp") == "/workspace"
+            # Falls back to first root for unknown paths
+            assert d._find_project_root("/other/path") == "/git"
+
+    def test_scan_projects_returns_absolute(self):
+        """_scan_projects returns absolute paths."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create two roots with git repos
+            root1 = os.path.join(tmpdir, "root1")
+            root2 = os.path.join(tmpdir, "root2")
+            os.makedirs(os.path.join(root1, "proj1", ".git"))
+            os.makedirs(os.path.join(root2, "proj2", ".git"))
+
+            with patch.dict(
+                os.environ,
+                {"PROJECTS_ROOT": f"{root1}:{root2}"},
+            ):
+                d = HostDaemon("http://dummy:8000", "dummy")
+                projects = d._scan_projects()
+                assert os.path.join(root1, "proj1") in projects
+                assert os.path.join(root2, "proj2") in projects
+                # All paths are absolute
+                assert all(os.path.isabs(p) for p in projects)

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -61,9 +61,9 @@ podman run -d --name host-daemon --network=host \
 |----------|-------------|---------|
 | `DASHBOARD_URL` | URL of the hub backend | *(required)* |
 | `HOST_TOKEN` | Token from the host registration step | *(required)* |
-| `PROJECTS_ROOT` | Root directory for project scanning | *(required)* |
+| `PROJECTS_ROOT` | Root directory (or colon-separated list) for project scanning | `/git` |
 | `OTLP_PORT` | OTLP telemetry receiver port | `4318` |
-| `PROJECTS_DEPTH` | Max scan depth below `PROJECTS_ROOT` | `6` |
+| `PROJECTS_DEPTH` | Max scan depth below each `PROJECTS_ROOT` entry | `6` |
 | `GEMINI_API_KEY` | API key for Gemini CLI | — |
 | `CLAUDE_CODE_USE_VERTEX` | Set to `1` to use Vertex AI for Claude | — |
 | `CLOUD_ML_REGION` | GCP region (e.g., `us-east5`) | — |

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -38,7 +38,7 @@ export interface Host {
   status: string;
   created_at: string;
   projects?: {
-    projects_root: string;
+    projects_root: string | string[];
     available_projects: string[];
     available_tools?: (string | ToolInfo)[];
   };

--- a/frontend/src/components/dashboard/SpawnModal.tsx
+++ b/frontend/src/components/dashboard/SpawnModal.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   PlusCircle,
   X,
-  ChevronRight,
   RefreshCw,
   Folder,
   GitFork,
+  Search,
 } from 'lucide-react';
 import type { Agent, Host } from '../../api';
 
@@ -50,11 +50,40 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
     () => host.projects?.available_projects || [],
     [host.projects?.available_projects],
   );
+
+  // Compute display labels by stripping the common prefix
+  // from absolute paths for readability.
+  const projectsRoot = host.projects?.projects_root;
+  const roots = useMemo(
+    () =>
+      Array.isArray(projectsRoot)
+        ? projectsRoot
+        : projectsRoot
+          ? [projectsRoot]
+          : ['/git'],
+    [projectsRoot],
+  );
+  const stripPrefix = useMemo(() => {
+    if (roots.length === 1) return roots[0] + '/';
+    return '';
+  }, [roots]);
+  const displayLabel = (p: string) =>
+    stripPrefix && p.startsWith(stripPrefix) ? p.slice(stripPrefix.length) : p;
+
   const [selectedProject, setSelectedProject] = useState('');
+  const [projectSearch, setProjectSearch] = useState('');
   const [task, setTask] = useState('');
   const [resumeSession, setResumeSession] = useState(true);
   const [useWorktree, setUseWorktree] = useState(false);
   const showResume = supportsResumeProp ?? false;
+
+  // Filter projects by search query (case-insensitive
+  // substring match against the full path).
+  const filteredProjects = useMemo(() => {
+    if (!projectSearch) return projects;
+    const q = projectSearch.toLowerCase();
+    return projects.filter((p) => p.toLowerCase().includes(q));
+  }, [projects, projectSearch]);
 
   // Auto-select first project when list arrives
   useEffect(() => {
@@ -66,18 +95,15 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
 
   // Smart default: enable worktree isolation when another
   // agent is already active on the selected project.
-  // Uses the original project_dir for matching so
-  // worktree-isolated agents are counted too.
+  // Projects are absolute paths so direct comparison works.
   useEffect(() => {
     if (!selectedProject) return;
-    const projectsRoot = host.projects?.projects_root || '/git';
-    const fullPath = `${projectsRoot}/${selectedProject}`;
     const hasActiveAgent = activeAgents.some(
-      (a) => a.telemetry?.project_dir === fullPath,
+      (a) => a.telemetry?.project_dir === selectedProject,
     );
     // eslint-disable-next-line react-hooks/set-state-in-effect -- derive from props
     setUseWorktree(hasActiveAgent);
-  }, [selectedProject, activeAgents, host.projects?.projects_root]);
+  }, [selectedProject, activeAgents]);
 
   // When worktree is enabled, force session mode to "new"
   // since the worktree has no prior session state.
@@ -122,39 +148,55 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
                 Refresh
               </button>
             </div>
-            <div className="relative group">
-              <Folder
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500 group-hover:text-accent transition-colors"
-                size={18}
+            <div className="relative">
+              <Search
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500"
+                size={14}
               />
-              <select
-                value={selectedProject}
-                onChange={(e) => setSelectedProject(e.target.value)}
-                className="w-full bg-slate-900 border border-slate-700 rounded-lg py-2.5 pl-10 pr-10 text-slate-50 focus:outline-none focus:border-accent appearance-none transition-all cursor-pointer"
-              >
-                {projects.length === 0 && (
-                  <option value="">
-                    Loading projects from{' '}
-                    {host.projects?.projects_root || '/git'}
-                    ...
-                  </option>
-                )}
-                {projects.map((p) => (
-                  <option key={p} value={p}>
-                    {p}
-                  </option>
-                ))}
-              </select>
-              <ChevronRight
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 pointer-events-none group-hover:text-accent rotate-90"
-                size={18}
+              <input
+                type="text"
+                value={projectSearch}
+                onChange={(e) => setProjectSearch(e.target.value)}
+                placeholder="Search projects..."
+                className="w-full bg-slate-900 border border-slate-700 rounded-lg py-2 pl-9 pr-4 text-sm text-slate-50 focus:outline-none focus:border-accent transition-colors"
               />
             </div>
-            <p className="text-[10px] text-slate-500 mt-1.5 italic">
-              Projects found in{' '}
-              <code className="bg-slate-900 px-1 rounded">
-                {host.projects?.projects_root || '/git'}
-              </code>
+            <div className="mt-1.5 max-h-48 overflow-y-auto bg-slate-900 border border-slate-700 rounded-lg">
+              {projects.length === 0 ? (
+                <p className="text-sm text-slate-500 px-3 py-2 italic">
+                  Loading projects from {roots.join(', ')}...
+                </p>
+              ) : filteredProjects.length === 0 ? (
+                <p className="text-sm text-slate-500 px-3 py-2 italic">
+                  No projects match &ldquo;{projectSearch}&rdquo;
+                </p>
+              ) : (
+                filteredProjects.map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => setSelectedProject(p)}
+                    className={`w-full text-left px-3 py-1.5 text-sm font-mono flex items-center gap-2 transition-colors ${
+                      selectedProject === p
+                        ? 'bg-accent/20 text-accent'
+                        : 'text-slate-300 hover:bg-slate-800'
+                    }`}
+                  >
+                    <Folder size={12} className="shrink-0" />
+                    {displayLabel(p)}
+                  </button>
+                ))
+              )}
+            </div>
+            <p className="text-[10px] text-slate-500 mt-1 italic">
+              {roots.length === 1 ? (
+                <>
+                  Projects from{' '}
+                  <code className="bg-slate-900 px-1 rounded">{roots[0]}</code>
+                </>
+              ) : (
+                <>Projects from {roots.length} directories</>
+              )}
             </p>
           </div>
 

--- a/frontend/src/components/dashboard/SpawnModal.tsx
+++ b/frontend/src/components/dashboard/SpawnModal.tsx
@@ -95,9 +95,9 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
 
   // Smart default: enable worktree isolation when another
   // agent is already active on the selected project.
-  // Handle both absolute paths (new daemons) and relative
-  // paths (old daemons) by checking both the raw value
-  // and the joined path.
+  // Only runs when the project selection changes — not
+  // on activeAgents updates — so it doesn't override
+  // user manual toggles.
   useEffect(() => {
     if (!selectedProject) return;
     const fullPath = selectedProject.startsWith('/')
@@ -110,7 +110,8 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
     );
     // eslint-disable-next-line react-hooks/set-state-in-effect -- derive from props
     setUseWorktree(hasActiveAgent);
-  }, [selectedProject, activeAgents, roots]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally omit activeAgents to avoid overriding user toggles
+  }, [selectedProject, roots]);
 
   // When worktree is enabled, force session mode to "new"
   // since the worktree has no prior session state.

--- a/frontend/src/components/dashboard/SpawnModal.tsx
+++ b/frontend/src/components/dashboard/SpawnModal.tsx
@@ -162,6 +162,7 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
                 size={14}
               />
               <input
+                autoFocus
                 type="text"
                 value={projectSearch}
                 onChange={(e) => setProjectSearch(e.target.value)}

--- a/frontend/src/components/dashboard/SpawnModal.tsx
+++ b/frontend/src/components/dashboard/SpawnModal.tsx
@@ -95,15 +95,22 @@ const SpawnModal: React.FC<SpawnModalProps> = ({
 
   // Smart default: enable worktree isolation when another
   // agent is already active on the selected project.
-  // Projects are absolute paths so direct comparison works.
+  // Handle both absolute paths (new daemons) and relative
+  // paths (old daemons) by checking both the raw value
+  // and the joined path.
   useEffect(() => {
     if (!selectedProject) return;
+    const fullPath = selectedProject.startsWith('/')
+      ? selectedProject
+      : `${roots[0]}/${selectedProject}`;
     const hasActiveAgent = activeAgents.some(
-      (a) => a.telemetry?.project_dir === selectedProject,
+      (a) =>
+        a.telemetry?.project_dir === selectedProject ||
+        a.telemetry?.project_dir === fullPath,
     );
     // eslint-disable-next-line react-hooks/set-state-in-effect -- derive from props
     setUseWorktree(hasActiveAgent);
-  }, [selectedProject, activeAgents]);
+  }, [selectedProject, activeAgents, roots]);
 
   // When worktree is enabled, force session mode to "new"
   // since the worktree has no prior session state.

--- a/tui/screens/spawn.py
+++ b/tui/screens/spawn.py
@@ -55,6 +55,7 @@ class SpawnScreen(Screen):
         self.agents = agents or []
         self._selected_host_id: int | None = None
         self._projects: List[str] = []
+        self._strip_prefix: str = ""
 
     def compose(self) -> ComposeResult:
         """Builds the spawn screen layout."""
@@ -83,8 +84,12 @@ class SpawnScreen(Screen):
                 prompt="Select host first",
             )
 
-            # Project selector
+            # Project search and selector
             yield Label("Project", classes="field-label")
+            yield Input(
+                placeholder="Search projects...",
+                id="project-search",
+            )
             yield Select(
                 [],
                 id="project-select",
@@ -136,9 +141,13 @@ class SpawnScreen(Screen):
             if host and host.get("projects"):
                 projects = host["projects"].get("available_projects", [])
                 raw_tools = host["projects"].get("available_tools", [])
+                pr = host["projects"].get("projects_root", "/git")
+                roots = pr if isinstance(pr, list) else [pr]
+                self._strip_prefix = roots[0] + "/" if len(roots) == 1 else ""
             else:
                 projects = []
                 raw_tools = []
+                self._strip_prefix = ""
             self._projects = projects
 
             # Update tool selector from host's profiles
@@ -157,12 +166,11 @@ class SpawnScreen(Screen):
                 ]
             tool_select.set_options(tool_options)
 
-            # Update project selector
+            # Update project selector and clear search
             project_select = self.query_one("#project-select", Select)
-            if projects:
-                project_select.set_options([(p, p) for p in projects])
-            else:
-                project_select.set_options([])
+            project_select.set_options(self._project_options(projects))
+            search_input = self.query_one("#project-search", Input)
+            search_input.value = ""
 
             # Smart worktree default: enable if another
             # agent is active on the selected project
@@ -171,32 +179,49 @@ class SpawnScreen(Screen):
         elif event.select.id == "project-select":
             self._update_worktree_default()
 
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filters the project list as the user types."""
+        if event.input.id != "project-search":
+            return
+        query = event.value.strip().lower()
+        project_select = self.query_one("#project-select", Select)
+        if not query:
+            project_select.set_options(self._project_options(self._projects))
+        else:
+            filtered = [p for p in self._projects if query in p.lower()]
+            project_select.set_options(self._project_options(filtered))
+
+    def _project_options(self, projects):
+        """Builds Select options from project paths.
+
+        Strips the common root prefix for single-root
+        configs to keep labels readable.
+        """
+        if not projects:
+            return []
+        prefix = self._strip_prefix or ""
+        return [
+            (
+                p[len(prefix) :] if prefix and p.startswith(prefix) else p,
+                p,
+            )
+            for p in projects
+        ]
+
     def _update_worktree_default(self) -> None:
         """Sets worktree toggle based on whether another
         agent is already active on the selected project.
+        Projects are absolute paths so direct comparison
+        works without joining with projects_root.
         """
         project_select = self.query_one("#project-select", Select)
         selected_project = project_select.value
         if selected_project is Select.BLANK:
             return
 
-        # Check if any active agent is on this project
-        # on the selected host
-        host = None
-        for h in self.hosts:
-            if h.get("id") == self._selected_host_id:
-                host = h
-                break
-        if not host:
-            return
-        projects_root = ""
-        if host.get("projects"):
-            projects_root = host["projects"].get("projects_root", "/git")
-        full_path = f"{projects_root}/{selected_project}"
-
         has_active = any(
             a.get("host_id") == self._selected_host_id
-            and (a.get("telemetry") or {}).get("project_dir") == full_path
+            and (a.get("telemetry") or {}).get("project_dir") == selected_project
             for a in self.agents
         )
         worktree_switch = self.query_one("#worktree-switch", Switch)


### PR DESCRIPTION
## Summary

Adds support for colon-separated `PROJECTS_ROOT` paths (e.g., `PROJECTS_ROOT=/git:/workspace`) so users with projects across multiple directories no longer need symlinks or multiple daemon instances. Also adds a searchable project selector to both the web UI and TUI, plus several bug fixes discovered during testing.

### Daemon
- Parse `PROJECTS_ROOT` as a colon-separated list (single path works as before)
- `_scan_projects()` iterates all roots, returning absolute paths instead of root-relative paths
- `report_projects()` sends `projects_root` as a list
- `_find_project_root()` helper determines which root a project belongs to for worktree storage
- Worktree creation and detection updated to check all roots
- Fix worktree agents showing worktree directory name instead of real project name — initial git info and periodic updater now read project name/remote from original project dir

### Frontend (SpawnModal)
- Replace `<select>` dropdown with a searchable project list: search input with case-insensitive substring filtering above a scrollable clickable list
- Autofocus search input so users can type immediately when the modal opens
- Strip common root prefix for single-root display readability (e.g., `/git/org/project` shows as `org/project`)
- Show full paths for multi-root configs
- Fix worktree toggle overriding user input — smart default now only fires on project selection change, not on every `activeAgents` polling update
- Worktree default detection handles both absolute (new daemon) and relative (old daemon) project paths for backward compatibility
- Handle `projects_root` as `string | string[]`

### TUI (Spawn Screen)
- Add search `Input` widget above project `Select` with real-time filtering
- `_project_options()` strips common prefix for single-root readability
- Worktree detection uses direct absolute path comparison
- Handle `projects_root` as string or list

### Profile Updates
- Mount `~/.claude.json` for MCP server config (#64) — Claude reads MCP configs from this file separately from `~/.claude/`

### Backend
- No changes needed — passes `projects_root` and `project_dir` through without inspecting them

### Backward Compatibility
- Single `PROJECTS_ROOT=/git` works exactly as before (list with one element)
- Frontend handles `projects_root` as either string or string[] via type union
- Worktree default detection works with both old (relative) and new (absolute) daemon paths

## Test plan
- [ ] `PROJECTS_ROOT=/git` — works as before, projects shown with relative display paths
- [ ] `PROJECTS_ROOT=/git:/workspace` — both roots scanned, all projects shown
- [ ] Spawn agent in a project from the second root — correct working directory
- [ ] Worktree on second root — stored under that root's `.agent-worktrees/`
- [ ] Worktree agent shows real project name, not worktree directory name
- [ ] Search filtering works in both web UI and TUI
- [ ] Search input autofocused on modal open
- [ ] Smart worktree default detects existing agents but doesn't override manual toggle
- [ ] Empty/nonexistent roots in the list are silently skipped
- [ ] Claude sessions have MCP servers from `~/.claude.json`
- [ ] All 62 unit tests pass (6 new)

Closes #61
Partially addresses #64 (items 1 and 3; item 2 remains open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)