### PR TITLE
Route terminal input to agent rooms to fix typing latency

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -149,9 +149,25 @@ class HostDaemon:
 
         @self.sio.on("*", namespace="/terminal")
         async def catch_all(event, data):
-            # Suppress noisy heartbeat/terminal output logs in debug
-            if event not in ["terminal_output", "terminal_input"]:
-                print(f"DEBUG: Received event '{event}' with data: {data}")
+            if event in ("terminal_output", "terminal_input"):
+                return
+            # Summarize large payloads to avoid blocking
+            # the event loop with synchronous print() calls.
+            if event == "host_telemetry_update":
+                tel = data.get("telemetry", {})
+                n = len(tel.get("available_projects", []))
+                hid = data.get("host_id")
+                print(f"DEBUG: {event} host_id={hid}" f" projects={n}")
+            elif event == "agent_telemetry_update":
+                aid = data.get("agent_id", "?")[:8]
+                tel = data.get("telemetry", {})
+                print(
+                    f"DEBUG: {event} agent={aid}"
+                    f" model={tel.get('model', '?')}"
+                    f" status={tel.get('agent_status', '?')}"
+                )
+            else:
+                print(f"DEBUG: Received event" f" '{event}' with data: {data}")
 
         @self.sio.on("connect", namespace="/terminal")
         async def on_connect():

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -9,6 +9,7 @@ relay I/O via Socket.IO, and receive OpenTelemetry data.
 import asyncio
 import fcntl
 import json
+import logging
 import os
 import pty
 import re
@@ -27,6 +28,13 @@ import socketio
 from aiohttp import web
 
 from agent.profiles import load_profiles
+
+logging.basicConfig(
+    format="%(asctime)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=logging.INFO,
+)
+log = logging.getLogger("daemon")
 
 # Default permission patterns — generic prompts that
 # apply to all agent tools. Tool-specific patterns are
@@ -152,26 +160,26 @@ class HostDaemon:
             if event in ("terminal_output", "terminal_input"):
                 return
             # Summarize large payloads to avoid blocking
-            # the event loop with synchronous print() calls.
+            # the event loop with synchronous logging calls.
             if event == "host_telemetry_update":
                 tel = data.get("telemetry", {})
                 n = len(tel.get("available_projects", []))
                 hid = data.get("host_id")
-                print(f"DEBUG: {event} host_id={hid}" f" projects={n}")
+                log.info(f"DEBUG: {event} host_id={hid}" f" projects={n}")
             elif event == "agent_telemetry_update":
                 aid = data.get("agent_id", "?")[:8]
                 tel = data.get("telemetry", {})
-                print(
+                log.info(
                     f"DEBUG: {event} agent={aid}"
                     f" model={tel.get('model', '?')}"
                     f" status={tel.get('agent_status', '?')}"
                 )
             else:
-                print(f"DEBUG: Received event" f" '{event}' with data: {data}")
+                log.info(f"DEBUG: Received event" f" '{event}' with data: {data}")
 
         @self.sio.on("connect", namespace="/terminal")
         async def on_connect():
-            print(f"Connected to dashboard at {self.server_url}")
+            log.info(f"Connected to dashboard at {self.server_url}")
             # Report available projects immediately on connection
             await self.report_projects()
             # Rejoin agent rooms so the backend can route
@@ -182,7 +190,7 @@ class HostDaemon:
                     {"room": aid},
                     namespace="/terminal",
                 )
-                print(f"Rejoined agent room: {aid}")
+                log.info(f"Rejoined agent room: {aid}")
 
         @self.sio.on("request_projects", namespace="/terminal")
         async def on_request_projects(data):
@@ -201,7 +209,7 @@ class HostDaemon:
                 try:
                     fcntl.ioctl(master_fd, termios.TIOCSWINSZ, size)
                 except Exception as e:
-                    print(f"Failed to resize terminal {agent_id}: {e}")
+                    log.info(f"Failed to resize terminal {agent_id}: {e}")
 
         @self.sio.on("spawn_agent", namespace="/terminal")
         async def on_spawn_agent(data):
@@ -231,7 +239,7 @@ class HostDaemon:
                     rows,
                 )
             except Exception as e:
-                print(f"Failed to spawn agent {agent_id}: {e}")
+                log.info(f"Failed to spawn agent {agent_id}: {e}")
                 if self.sio.connected:
                     await self.sio.emit(
                         "agent_status_update",
@@ -246,7 +254,7 @@ class HostDaemon:
         async def on_stop_agent(data):
             agent_id = data.get("agent_id")
             if agent_id in self.agents:
-                print(f"Stopping agent {agent_id} by request.")
+                log.info(f"Stopping agent {agent_id} by request.")
                 pid = self.agents[agent_id]["pid"]
                 try:
                     os.kill(pid, signal.SIGTERM)
@@ -269,7 +277,7 @@ class HostDaemon:
         async def on_request_history(data):
             agent_id = data.get("agent_id")
             if agent_id in self.agents and self.sio.connected:
-                print(f"Replaying history for agent: {agent_id}")
+                log.info(f"Replaying history for agent: {agent_id}")
                 for chunk in self.agents[agent_id]["history"]:
                     await self.sio.emit(
                         "terminal_output",
@@ -322,7 +330,7 @@ class HostDaemon:
                             projects.append(os.path.join(scan_root, rel_path))
                         dirs[:] = [d for d in dirs if d != ".git"]
             except Exception as e:
-                print(f"Error scanning projects root {scan_root}: {e}")
+                log.info(f"Error scanning projects root {scan_root}: {e}")
         projects.sort()
         return projects
 
@@ -339,7 +347,7 @@ class HostDaemon:
                 if self.sio.connected:
                     await self.report_projects()
             except Exception as e:
-                print(f"Project cache update failed: {e}")
+                log.info(f"Project cache update failed: {e}")
 
             await asyncio.sleep(60)
 
@@ -416,7 +424,7 @@ class HostDaemon:
                 if all(os.getenv(v) for v in profile.auth.env_vars):
                     tools.append(self._make_tool_info(profile))
                 else:
-                    print(
+                    log.info(
                         f"{profile.display_name} CLI found "
                         f"but auth not configured — "
                         f"not advertising."
@@ -425,12 +433,12 @@ class HostDaemon:
                 if any(os.getenv(v) for v in profile.auth.env_vars):
                     tools.append(self._make_tool_info(profile))
                 else:
-                    print(
+                    log.info(
                         f"{profile.display_name} CLI found "
                         f"but auth not configured — "
                         f"not advertising."
                     )
-        print(f"Available tools: {tools}")
+        log.info(f"Available tools: {tools}")
         return tools
 
     async def scan_and_report_projects(self):
@@ -442,7 +450,7 @@ class HostDaemon:
         new_projects = await loop.run_in_executor(None, self._scan_projects)
         async with self.projects_lock:
             self.cached_projects = new_projects
-        print(f"Force rescan: found {len(new_projects)} projects.")
+        log.info(f"Force rescan: found {len(new_projects)} projects.")
         await self.report_projects()
 
     async def report_projects(self):
@@ -453,7 +461,7 @@ class HostDaemon:
             projects = list(self.cached_projects)
 
         tools = self._detect_available_tools()
-        print(f"Reporting {len(projects)} projects, {len(tools)} tools to Hub.")
+        log.info(f"Reporting {len(projects)} projects, {len(tools)} tools to Hub.")
         if self.sio.connected:
             await self.sio.emit(
                 "host_telemetry",
@@ -594,7 +602,7 @@ class HostDaemon:
                         if name not in servers:
                             servers.append(name)
         except Exception as e:
-            print(f"MCP detection error for {tool}: {e}")
+            log.info(f"MCP detection error for {tool}: {e}")
 
         return servers
 
@@ -677,12 +685,12 @@ class HostDaemon:
                 full_path = worktree_dir
                 # Worktrees have no prior session state
                 session_mode = "new"
-                print(
+                log.info(
                     f"Created worktree for {agent_id}: "
                     f"{worktree_dir} (branch {worktree_branch})"
                 )
             except Exception as e:
-                print(
+                log.info(
                     f"Failed to create worktree for "
                     f"{agent_id}: {e}. "
                     f"Falling back to original directory."
@@ -726,7 +734,7 @@ class HostDaemon:
             except Exception:
                 pass
 
-        print(
+        log.info(
             f"Spawning agent {agent_id} with tool: {tool} "
             f"mode: {session_mode} in {full_path}"
         )
@@ -809,7 +817,7 @@ class HostDaemon:
             try:
                 os.execvpe(cmd[0], cmd, env)
             except Exception as e:
-                print(f"Failed to execute {cmd}: {e}")
+                log.info(f"Failed to execute {cmd}: {e}")
                 os._exit(1)
         else:  # Parent process
             # Set initial PTY dimensions before the agent
@@ -820,7 +828,7 @@ class HostDaemon:
                 size = struct.pack("HHHH", rows, cols, 0, 0)
                 fcntl.ioctl(fd, termios.TIOCSWINSZ, size)
             except Exception as e:
-                print(f"Failed to set initial PTY size " f"for {agent_id}: {e}")
+                log.info(f"Failed to set initial PTY size " f"for {agent_id}: {e}")
 
             self.agents[agent_id] = {
                 "master_fd": fd,
@@ -853,7 +861,7 @@ class HostDaemon:
                     {"room": agent_id},
                     namespace="/terminal",
                 )
-                print(f"Joined agent room: {agent_id}")
+                log.info(f"Joined agent room: {agent_id}")
             os.write(fd, b"\n")
 
     async def watch_agents(self):
@@ -952,7 +960,7 @@ class HostDaemon:
     def close_agent(self, agent_id: str):
         """Closes the PTY fd and removes an agent from tracking."""
         if agent_id in self.agents:
-            print(f"Closing agent {agent_id}")
+            log.info(f"Closing agent {agent_id}")
             fd = self.agents[agent_id]["master_fd"]
             try:
                 os.close(fd)
@@ -982,9 +990,9 @@ class HostDaemon:
                         capture_output=True,
                         check=False,
                     )
-                    print(f"Removed worktree {wt_path}")
+                    log.info(f"Removed worktree {wt_path}")
                 except Exception as e:
-                    print(f"Failed to remove worktree {wt_path}: {e}")
+                    log.info(f"Failed to remove worktree {wt_path}: {e}")
                 if wt_branch:
                     try:
                         subprocess.run(
@@ -994,7 +1002,7 @@ class HostDaemon:
                             check=False,
                         )
                     except Exception as e:
-                        print(f"Failed to delete branch {wt_branch}: {e}")
+                        log.info(f"Failed to delete branch {wt_branch}: {e}")
                 # Clean up empty parent directories
                 try:
                     parent = os.path.dirname(wt_path)
@@ -1213,12 +1221,12 @@ class HostDaemon:
         """
         try:
             data = await request.json()
-            print(f"OTLP received on {request.path}: " f"{list(data.keys())}")
+            log.info(f"OTLP received on {request.path}: " f"{list(data.keys())}")
 
             # Optional verbose debug mode for inspecting
             # raw OTLP payloads from agent tools.
             if os.getenv("OTLP_DEBUG"):
-                print(
+                log.info(
                     f"OTLP DEBUG {request.path}:\n"
                     f"{json.dumps(data, indent=2, default=str)}"
                 )
@@ -1232,7 +1240,9 @@ class HostDaemon:
                 agent_id = self._resolve_agent_id(res_attrs)
 
                 if not agent_id:
-                    print(f"OTLP: no agent match for resource " f"attrs: {res_attrs}")
+                    log.info(
+                        f"OTLP: no agent match for resource " f"attrs: {res_attrs}"
+                    )
                     continue
                 tel = self.agents[agent_id]["telemetry"]
                 changed = False
@@ -1442,7 +1452,7 @@ class HostDaemon:
 
             return web.Response(status=200)
         except Exception as e:
-            print(f"OTLP Error: {e}")
+            log.info(f"OTLP Error: {e}")
             return web.Response(status=400)
 
     async def start_otlp_server(self):
@@ -1454,7 +1464,7 @@ class HostDaemon:
         self.otlp_runner = web.AppRunner(app)
         await self.otlp_runner.setup()
         site = web.TCPSite(self.otlp_runner, "127.0.0.1", self.otlp_port)
-        print(f"OTLP Receiver listening on " f"http://127.0.0.1:{self.otlp_port}")
+        log.info(f"OTLP Receiver listening on " f"http://127.0.0.1:{self.otlp_port}")
         await site.start()
 
     async def update_agent_status(self):
@@ -1597,8 +1607,8 @@ class HostDaemon:
             except asyncio.CancelledError:
                 return
             except Exception as e:
-                print(f"Background task '{name}' failed: {e}")
-                print(f"Restarting '{name}' in 5 seconds...")
+                log.info(f"Background task '{name}' failed: {e}")
+                log.info(f"Restarting '{name}' in 5 seconds...")
                 await asyncio.sleep(5)
 
     async def run(self):
@@ -1637,7 +1647,7 @@ class HostDaemon:
         except asyncio.CancelledError:
             pass
         except Exception as e:
-            print(f"Daemon error: {e}")
+            log.info(f"Daemon error: {e}")
         finally:
             self.running = False
             if self.otlp_runner:
@@ -1646,11 +1656,11 @@ class HostDaemon:
                 self.close_agent(agent_id)
             if self.sio.connected:
                 await self.sio.disconnect()
-            print("Daemon stopped.")
+            log.info("Daemon stopped.")
 
     def stop(self):
         """Signals all background tasks to stop."""
-        print("\nShutting down daemon...")
+        log.info("\nShutting down daemon...")
         self.running = False
         if hasattr(self, "watcher_task") and not self.watcher_task.done():
             self.watcher_task.cancel()
@@ -1667,7 +1677,7 @@ async def main():
     server_url = os.getenv("DASHBOARD_URL", "http://localhost:8000")
     host_token = os.getenv("HOST_TOKEN")
     if not host_token:
-        print("Error: HOST_TOKEN environment variable is required.")
+        log.info("Error: HOST_TOKEN environment variable is required.")
         sys.exit(1)
     daemon = HostDaemon(server_url, host_token)
     loop = asyncio.get_running_loop()

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -166,6 +166,7 @@ class HostDaemon:
                     {"room": aid},
                     namespace="/terminal",
                 )
+                print(f"Rejoined agent room: {aid}")
 
         @self.sio.on("request_projects", namespace="/terminal")
         async def on_request_projects(data):
@@ -836,6 +837,7 @@ class HostDaemon:
                     {"room": agent_id},
                     namespace="/terminal",
                 )
+                print(f"Joined agent room: {agent_id}")
             os.write(fd, b"\n")
 
     async def watch_agents(self):

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -158,6 +158,14 @@ class HostDaemon:
             print(f"Connected to dashboard at {self.server_url}")
             # Report available projects immediately on connection
             await self.report_projects()
+            # Rejoin agent rooms so the backend can route
+            # terminal_input and terminal_resize to us.
+            for aid in self.agents:
+                await self.sio.emit(
+                    "join_room",
+                    {"room": aid},
+                    namespace="/terminal",
+                )
 
         @self.sio.on("request_projects", namespace="/terminal")
         async def on_request_projects(data):
@@ -819,6 +827,13 @@ class HostDaemon:
                         "agent_id": agent_id,
                         "telemetry": telemetry,
                     },
+                    namespace="/terminal",
+                )
+                # Join the agent's room so the backend
+                # routes terminal_input to this daemon.
+                await self.sio.emit(
+                    "join_room",
+                    {"room": agent_id},
                     namespace="/terminal",
                 )
             os.write(fd, b"\n")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -230,11 +230,6 @@ def read_hosts(
     List all registered hosts. Requires UI login.
     """
     hosts = db.query(models.Host).offset(skip).limit(limit).all()
-    print(
-        f"DEBUG: read_hosts returning {len(hosts)} hosts."
-        f" Sample projects:"
-        f" {[h.last_projects_json for h in hosts]}"
-    )
     return hosts
 
 

--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -104,14 +104,22 @@ async def handle_terminal_output(sid, data):
 @sio.on("join_room", namespace="/terminal")
 async def handle_join_room(sid, data):
     """
-    Allows the UI to join a specific agent's room to receive its output.
+    Adds a client to an agent's room. Used by both UI
+    clients (to receive output) and host daemons (to
+    receive room-targeted input and resize events).
     """
     agent_id = data.get("room")
     if agent_id:
         await sio.enter_room(sid, agent_id, namespace="/terminal")
-        print(f"UI Client {sid} joined Agent room: {agent_id}")
+        # Identify whether this is a daemon or UI client
+        async with sio.session(sid, namespace="/terminal") as session:
+            is_host = session.get("is_host", False)
+        client_type = "Host Daemon" if is_host else "UI Client"
+        print(f"{client_type} {sid} joined Agent room: {agent_id}")
 
         # Request history replay from the host daemon
+        # (only meaningful for UI clients, but harmless
+        # if a daemon receives its own history request)
         await sio.emit("request_history", {"agent_id": agent_id}, namespace="/terminal")
 
 

--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -167,9 +167,6 @@ async def handle_agent_telemetry(sid, data):
     """
     agent_id = data.get("agent_id")
     telemetry = data.get("telemetry")
-    print(
-        f"DEBUG: handle_agent_telemetry received for agent_id {agent_id}: {telemetry}"
-    )
     if agent_id and telemetry:
         db = next(database.get_db())
         try:
@@ -185,8 +182,6 @@ async def handle_agent_telemetry(sid, data):
                 new_tel.update(telemetry)
                 db_agent.telemetry_json = new_tel
                 db.commit()
-                msg = f"DEBUG: successfully updated DB for agent {agent_id}"
-                print(msg)
 
                 # Broadcast update to all UI clients for real-time card refresh
                 await sio.emit(
@@ -208,7 +203,14 @@ async def handle_host_telemetry(sid, data):
     """
     async with sio.session(sid, namespace="/terminal") as session:
         host_id = session.get("host_id")
-        print(f"Received host_telemetry from SID {sid} (Host ID: {host_id}): {data}")
+        n_projects = len(data.get("available_projects", []))
+        n_tools = len(data.get("available_tools", []))
+        print(
+            f"Received host_telemetry from"
+            f" Host ID: {host_id}"
+            f" ({n_projects} projects,"
+            f" {n_tools} tools)"
+        )
         if host_id:
             db = next(database.get_db())
             try:

--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -137,10 +137,17 @@ async def handle_history_complete(sid, data):
 @sio.on("terminal_resize", namespace="/terminal")
 async def handle_terminal_resize(sid, data):
     """
-    Relays a terminal resize event from UI to all host daemons.
+    Relays a terminal resize event to the agent's room.
     data: {'sid': 'agent_id', 'cols': 80, 'rows': 24}
     """
-    await sio.emit("terminal_resize", data, namespace="/terminal")
+    agent_id = data.get("sid")
+    if agent_id:
+        await sio.emit(
+            "terminal_resize",
+            data,
+            room=agent_id,
+            namespace="/terminal",
+        )
 
 
 @sio.on("agent_telemetry", namespace="/terminal")
@@ -244,9 +251,15 @@ async def handle_agent_exit(sid, data):
 @sio.on("terminal_input", namespace="/terminal")
 async def handle_terminal_input(sid, data):
     """
-    Receives keystrokes from the UI and relays them to the Host Daemon.
+    Relays keystrokes to the agent's room where only
+    the owning daemon receives them.
     data: {'target_sid': 'agent_id', 'input': '...'}
     """
-    # Relay directly to all connected clients on this namespace.
-    # The Host Daemon will filter by agent_id.
-    await sio.emit("terminal_input", data, namespace="/terminal")
+    agent_id = data.get("target_sid")
+    if agent_id:
+        await sio.emit(
+            "terminal_input",
+            data,
+            room=agent_id,
+            namespace="/terminal",
+        )

--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -112,8 +112,8 @@ async def handle_join_room(sid, data):
     if agent_id:
         await sio.enter_room(sid, agent_id, namespace="/terminal")
         # Identify whether this is a daemon or UI client
-        async with sio.session(sid, namespace="/terminal") as session:
-            is_host = session.get("is_host", False)
+        session = await sio.get_session(sid, namespace="/terminal")
+        is_host = session.get("is_host", False) if session else False
         client_type = "Host Daemon" if is_host else "UI Client"
         print(f"{client_type} {sid} joined Agent room: {agent_id}")
 

--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -117,10 +117,16 @@ async def handle_join_room(sid, data):
         client_type = "Host Daemon" if is_host else "UI Client"
         print(f"{client_type} {sid} joined Agent room: {agent_id}")
 
-        # Request history replay from the host daemon
-        # (only meaningful for UI clients, but harmless
-        # if a daemon receives its own history request)
-        await sio.emit("request_history", {"agent_id": agent_id}, namespace="/terminal")
+        # Request history replay only for UI clients.
+        # Daemons join rooms for input routing, not for
+        # history — replaying history on daemon reconnect
+        # floods the connection and causes a reconnect loop.
+        if not is_host:
+            await sio.emit(
+                "request_history",
+                {"agent_id": agent_id},
+                namespace="/terminal",
+            )
 
 
 @sio.on("request_projects", namespace="/terminal")

--- a/backend/tests/test_e2e_socket.py
+++ b/backend/tests/test_e2e_socket.py
@@ -204,6 +204,12 @@ def test_socketio_relay_multiplex_e2e(live_server):
     )
     agent_id = r_spawn.json()["agent_id"]
 
+    # Host joins the agent's room (as the real daemon
+    # does after spawning) so it receives room-targeted
+    # terminal_input and terminal_resize events.
+    host_sio.emit("join_room", {"room": agent_id}, namespace="/terminal")
+    time.sleep(0.2)
+
     # 2. UI connects
     ui_sio = socketio.Client()
     ui_received_output = []

--- a/frontend/Containerfile
+++ b/frontend/Containerfile
@@ -18,9 +18,11 @@ FROM docker.io/library/node:22-slim AS build
 
 WORKDIR /app
 
-# Copy package files and install dependencies
+# Copy package files and install dependencies.
+# Retry on failure to handle intermittent npm
+# registry errors in CI.
 COPY frontend/package*.json ./
-RUN npm ci
+RUN npm ci || (sleep 5 && npm ci)
 
 # Copy source and config files (node_modules stays from npm ci)
 COPY frontend/src/ src/

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -213,6 +213,12 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
 
     const term = new XTerm({
       cursorBlink: true,
+      // Cap scrollback to limit memory growth in long
+      // sessions. Agent output with heavy escape sequences
+      // (cursor movement, progress bars, color codes) can
+      // consume orders of magnitude more memory per line
+      // than plain text.
+      scrollback: 2000,
       theme: {
         background: '#000000',
         foreground: '#f1f5f9',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ disable = [
     "too-many-instance-attributes",
     "too-many-arguments",
     "too-many-positional-arguments",
+    "logging-fstring-interpolation",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary

Routes terminal input and resize events to specific agent rooms instead of broadcasting to the entire Socket.IO namespace. Also includes several performance fixes, a regression fix, and logging improvements discovered during testing.

### Room-Targeted Input (core change)
- **Daemon**: Emits `join_room` for each agent after spawn and on reconnect, joining the daemon's SID to the agent's room
- **Backend**: `handle_terminal_input` and `handle_terminal_resize` emit to `room=agent_id` instead of namespace broadcast
- **Impact**: O(1) message per keystroke instead of O(daemons × agents)

### Regression Fix: Reconnect Loop
- When the daemon reconnected and rejoined agent rooms, `handle_join_room` broadcast `request_history` for each agent. The daemon received its own history requests and replayed output for all agents simultaneously, flooding the socket and causing a reconnect loop (host flapping online/offline, terminal replaying buffer, input not accepted)
- Fix: only emit `request_history` when a UI client joins a room, not when a daemon joins

### Performance Fixes
- **Verbose telemetry logging**: Daemon's `catch_all` handler now summarizes `host_telemetry_update` (host_id + project count) and `agent_telemetry_update` (agent ID + model + status) instead of printing full JSON payloads that blocked the async event loop
- **Backend `read_hosts` debug print**: Removed print that dumped full `last_projects_json` for all hosts on every `GET /hosts` poll (every 5 seconds)
- **xterm.js scrollback**: Capped at 2000 lines to limit memory growth in long sessions. Agent output with heavy escape sequences consumed gigabytes over time, causing per-keystroke latency

### Logging Improvements
- **Daemon/UI identification**: `handle_join_room` now prints "Host Daemon" or "UI Client" based on session `is_host` flag, with `get_session()` instead of context manager to avoid timing issues
- **Daemon timestamps**: All `print()` calls replaced with `log.info()` using Python's `logging` module with `%(asctime)s` format. Enables correlating daemon events with backend logs and user-reported issues
- **pylint config**: Added `logging-fstring-interpolation` to disable list

### E2E Test Fix
- Simulated host in multiplex E2E test now joins the agent room after spawn, matching real daemon behavior

### Breaking Change
Daemon and backend must be updated together. An old daemon that doesn't join agent rooms won't receive room-targeted input from an updated backend.

## Test plan
- [ ] Spawn agent, type in terminal — input works
- [ ] Spawn agents on multiple hosts — input only goes to the correct daemon
- [ ] Restart daemon — input still works after reconnect, no reconnect loop
- [ ] Attach to existing session — history replays, input works
- [ ] Resize terminal — dimensions update correctly
- [ ] Long session (hours) — memory stays bounded, no per-keystroke latency
- [ ] Daemon logs show timestamps on all messages
- [ ] Backend logs show "Host Daemon" vs "UI Client" in room join messages
- [ ] All tests pass (62 daemon + 20 backend + E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)