### PR TITLE
Reduce dashboard REST polling from 5s to 30s

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -451,6 +451,8 @@ class HostDaemon:
         async with self.projects_lock:
             self.cached_projects = new_projects
         log.info(f"Force rescan: found {len(new_projects)} projects.")
+        # Invalidate tool cache so force-refresh re-detects
+        self._cached_tools = None
         await self.report_projects()
 
     async def report_projects(self):
@@ -460,7 +462,16 @@ class HostDaemon:
         async with self.projects_lock:
             projects = list(self.cached_projects)
 
-        tools = self._detect_available_tools()
+        # Use cached tools — _detect_available_tools() runs
+        # synchronous subprocess calls that block the event
+        # loop. Tools don't change at runtime so we detect
+        # once at startup and on explicit refresh.
+        if not hasattr(self, "_cached_tools") or not self._cached_tools:
+            loop = asyncio.get_running_loop()
+            self._cached_tools = await loop.run_in_executor(
+                None, self._detect_available_tools
+            )
+        tools = self._cached_tools
         log.info(f"Reporting {len(projects)} projects, {len(tools)} tools to Hub.")
         if self.sio.connected:
             await self.sio.emit(

--- a/frontend/Containerfile
+++ b/frontend/Containerfile
@@ -19,10 +19,13 @@ FROM docker.io/library/node:22-slim AS build
 WORKDIR /app
 
 # Copy package files and install dependencies.
-# Retry on failure to handle intermittent npm
-# registry errors in CI.
+# Verify axios is resolvable after install to catch
+# partial installs from intermittent npm registry
+# errors that exit 0 but leave node_modules incomplete.
 COPY frontend/package*.json ./
-RUN npm ci || (sleep 5 && npm ci)
+RUN npm ci \
+    && node -e "require.resolve('axios')" \
+    || (echo "Retrying npm ci..." && rm -rf node_modules && npm ci)
 
 # Copy source and config files (node_modules stays from npm ci)
 COPY frontend/src/ src/

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -157,13 +157,21 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
     socket.on(
       'agent_telemetry_update',
       (data: { agent_id: string; telemetry: Agent['telemetry'] }) => {
-        setAgents((prev) =>
-          prev.map((a) =>
+        setAgents((prev) => {
+          const exists = prev.some((a) => a.agent_id === data.agent_id);
+          if (!exists) {
+            // Agent not in state — likely spawned after
+            // a daemon reconnect cleared old records.
+            // Trigger a full fetch to pick up the new agent.
+            fetchData();
+            return prev;
+          }
+          return prev.map((a) =>
             a.agent_id === data.agent_id
               ? { ...a, telemetry: data.telemetry }
               : a,
-          ),
-        );
+          );
+        });
       },
     );
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -179,7 +179,10 @@ const Dashboard: React.FC<DashboardProps> = ({ onAttach }) => {
       },
     );
 
-    const interval = setInterval(fetchData, 5000);
+    // Poll as a safety net for missed socket events.
+    // Socket.IO handles real-time updates; this catches
+    // edge cases like agents spawned by other UI clients.
+    const interval = setInterval(fetchData, 30000);
     return () => {
       clearInterval(interval);
       socket.disconnect();


### PR DESCRIPTION
## Summary

Reduces dashboard REST polling overhead and fixes the persistent periodic typing latency caused by synchronous tool detection blocking the daemon's async event loop.

### Reduce REST polling from 5s to 30s (#73)
Socket.IO events already handle real-time updates for agent telemetry, agent status, and host telemetry. The REST poll is a safety net for missed events, not the primary data source. Reduces backend queries ~6x and React state churn.

### Cache tool detection to stop blocking the event loop
`_detect_available_tools()` runs `subprocess.run()` for each profile binary (claude, gemini, agy — each with a 5-second timeout) **synchronously on the async event loop**. With 3+ tools, this blocked the event loop for several seconds every 60 seconds when `report_projects()` was called from `update_projects_cache()`. This was the root cause of the persistent periodic typing latency (~every 1-2 minutes). Fixed by caching the result and running detection in an executor on first call. Cache is invalidated on force-refresh.

### Fetch agents on unknown telemetry update after reconnect
With the polling interval increased to 30s, agent cards that disappear during a daemon reconnect (stale cleanup) didn't reappear until the next poll — up to 30 seconds. Fixed by triggering `fetchData()` when `agent_telemetry_update` arrives for an agent ID not in the current React state, so the socket event drives immediate re-population.

### Fix flaky frontend container build
`npm ci` was exiting 0 with an incomplete `node_modules` due to intermittent npm registry errors. The previous retry only triggered on non-zero exit codes. Fixed by verifying `axios` is resolvable after install — if not, cleans `node_modules` and retries.

## Test plan
- [ ] Dashboard cards still update in real-time (telemetry, status)
- [ ] No periodic typing latency (~every 1-2 minutes)
- [ ] Spawning an agent shows the card immediately
- [ ] Stopping an agent removes the card immediately
- [ ] Daemon restart — agent cards reappear promptly (not 30s delay)
- [ ] Force refresh in spawn modal re-detects available tools
- [ ] Frontend container build succeeds reliably in CI

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)