### PR TITLE
Add Pi coding agent profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,17 +244,18 @@ podman run -d --name host-daemon --network=host --privileged \
   -v $HOME/.ssh:/root/.ssh:ro \
   -v $HOME/.gitconfig:/root/.gitconfig:ro \
   -v $HOME/.claude/:/root/.claude \
+  -v $HOME/.claude.json:/root/.claude.json:ro \
   -v $HOME/.gemini/:/root/.gemini \
+  -v $HOME/.pi:/root/.pi \
   localhost/agent-dashboard-daemon:latest
 ```
 
 > [!TIP]
 > **Missing config directories:** The volume mounts above
-> expect `~/.claude/` and `~/.gemini/` to exist on the host.
-> If you haven't used one of these tools locally, create the
-> directory first:
+> expect agent config directories to exist on the host.
+> If you haven't used these tools locally, create them first:
 > ```bash
-> mkdir -p ~/.claude ~/.gemini
+> mkdir -p ~/.claude ~/.gemini ~/.pi/agent
 > ```
 
 > [!TIP]

--- a/agent/Containerfile.template
+++ b/agent/Containerfile.template
@@ -104,16 +104,6 @@ RUN npm install -g {{ npm_packages | join(' ') }}
 RUN pip3 install --no-cache-dir {{ pip_packages | join(' ') }}
 {% endif %}
 
-# Pre-install Pi extensions for dashboard telemetry,
-# Vertex AI provider, and MCP server connectivity.
-# These are Pi-specific extensions (not npm globals).
-# Harmless if pi isn't installed (profile removed).
-# See docs/agent-profiles.md "Bundled Pi Extensions"
-# for selection rationale and replacement guidance.
-RUN pi install npm:pi-otel \
-    npm:@ssweens/pi-vertex \
-    npm:@0xkobold/pi-mcp \
-    2>/dev/null || true
 
 {% for cf in config_files %}
 {% if cf.mkdir and not cf.content %}

--- a/agent/Containerfile.template
+++ b/agent/Containerfile.template
@@ -104,6 +104,17 @@ RUN npm install -g {{ npm_packages | join(' ') }}
 RUN pip3 install --no-cache-dir {{ pip_packages | join(' ') }}
 {% endif %}
 
+# Pre-install Pi extensions for dashboard telemetry,
+# Vertex AI provider, and MCP server connectivity.
+# These are Pi-specific extensions (not npm globals).
+# Harmless if pi isn't installed (profile removed).
+# See docs/agent-profiles.md "Bundled Pi Extensions"
+# for selection rationale and replacement guidance.
+RUN pi install npm:pi-otel \
+    npm:@ssweens/pi-vertex \
+    npm:@0xkobold/pi-mcp \
+    2>/dev/null || true
+
 {% for cf in config_files %}
 {% if cf.mkdir and not cf.content %}
 RUN mkdir -p {{ cf.path }}

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -406,12 +406,15 @@ class HostDaemon:
             if profile.always_available:
                 tools.append(self._make_tool_info(profile))
                 continue
-            # Check if binary exists
+            # Check if binary exists. Use a generous
+            # timeout because some tools (e.g. Pi) load
+            # extensions during --version, which can take
+            # several seconds under load.
             try:
                 subprocess.run(
                     [profile.binary, "--version"],
                     capture_output=True,
-                    timeout=5,
+                    timeout=15,
                     check=False,
                 )
             except (OSError, subprocess.TimeoutExpired):

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1570,8 +1570,9 @@ class HostDaemon:
 
             return web.Response(
                 status=200,
-                body=b"{}",
+                text="{}",
                 content_type="application/json",
+                headers={"Connection": "close"},
             )
         except Exception as e:
             log.info(f"OTLP Error: {e}")

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1110,10 +1110,30 @@ class HostDaemon:
             if val is not None:
                 output_tokens = int(val)
                 break
-        for key in ("cache_read_tokens", "cache_creation_tokens"):
+        # Cache tokens — check both short names (Claude)
+        # and GenAI semconv names (pi-otel).
+        cache_read = None
+        cache_creation = None
+        for key in (
+            "cache_read_tokens",
+            "gen_ai.usage.cache_read_input_tokens",
+        ):
             val = attrs.get(key)
             if val is not None:
-                cache_tokens = (cache_tokens or 0) + int(val)
+                cache_read = int(val)
+                break
+        for key in (
+            "cache_creation_tokens",
+            "gen_ai.usage.cache_creation_input_tokens",
+        ):
+            val = attrs.get(key)
+            if val is not None:
+                cache_creation = int(val)
+                break
+        if cache_read is not None or cache_creation is not None:
+            cache_tokens = (cache_read or 0) + (cache_creation or 0)
+        else:
+            cache_tokens = None
 
         if input_tokens is not None or output_tokens is not None:
             total = (input_tokens or 0) + (output_tokens or 0) + (cache_tokens or 0)
@@ -1129,6 +1149,15 @@ class HostDaemon:
         if input_tokens is not None and input_tokens > 0:
             tel["context_tokens"] = input_tokens
             changed = True
+
+        # Cost — pi-otel puts cumulative session cost on
+        # pi.llm_request span attributes as pi.cost.usd.
+        cost = attrs.get("pi.cost.usd")
+        if cost is not None:
+            cost_f = float(cost)
+            if cost_f > tel.get("cost_usd", 0.0):
+                tel["cost_usd"] = cost_f
+                changed = True
 
         # Current activity — extract the latest tool/function
         # name from span or log attributes.  Gemini uses

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1268,6 +1268,8 @@ class HostDaemon:
             # Identify signal types present in the payload
             # for clearer logging (especially when requests
             # arrive on the root-path workaround route).
+            # TODO: Remove signal-sniffing once the root-path
+            # route is removed (see NikiforovAll/pi-otel#6).
             signals = [
                 k.replace("resource", "").lower()
                 for k in data
@@ -1560,6 +1562,12 @@ class HostDaemon:
         # passes cfg.endpoint as the exporter url option,
         # which bypasses the SDK's signal-path appending.
         # See: https://github.com/NikiforovAll/pi-otel/issues/4
+        #
+        # TODO: Remove this route once pi-otel merges the
+        # upstream fix (NikiforovAll/pi-otel#6) and a new
+        # release is published. The local patched copy in
+        # ~/.pi already has the fix, but upstream v0.1.0
+        # still sends to POST /.
         app.router.add_post("/", self.handle_otlp)
         self.otlp_runner = web.AppRunner(app)
         await self.otlp_runner.setup()

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1297,6 +1297,7 @@ class HostDaemon:
                 agent_id = self._resolve_agent_id(res_attrs)
 
                 if not agent_id:
+                    log.info("OTLP: no agent match for trace" f" resource: {res_attrs}")
                     continue
                 tel = self.agents[agent_id]["telemetry"]
                 changed = False
@@ -1358,6 +1359,9 @@ class HostDaemon:
                 agent_id = self._resolve_agent_id(res_attrs)
 
                 if not agent_id:
+                    log.info(
+                        "OTLP: no agent match for metric" f" resource: {res_attrs}"
+                    )
                     continue
                 tel = self.agents[agent_id]["telemetry"]
                 changed = False
@@ -1379,8 +1383,13 @@ class HostDaemon:
                             )
 
                             # Model detection from any metric with a
-                            # 'model' attribute
-                            model = dp_attrs.get("model")
+                            # 'model' attribute. GenAI conventions
+                            # also use gen_ai.response.model.
+                            model = (
+                                dp_attrs.get("model")
+                                or dp_attrs.get("gen_ai.response.model")
+                                or dp_attrs.get("gen_ai.request.model")
+                            )
                             if (
                                 model
                                 and isinstance(model, str)
@@ -1389,7 +1398,17 @@ class HostDaemon:
                                 tel["model"] = model
                                 changed = True
 
-                            # Token tracking from tool-specific
+                            # Extract the data point value. Sum and
+                            # Gauge metrics use asInt/asDouble.
+                            # Histogram metrics store cumulative
+                            # totals in the "sum" field instead.
+                            dp_value = (
+                                dp.get("asInt")
+                                or dp.get("asDouble")
+                                or dp.get("sum")
+                                or 0
+                            )
+
                             # Token, cost, activity, and runtime
                             # metrics are matched against the
                             # lookup tables built from agent
@@ -1397,16 +1416,22 @@ class HostDaemon:
                             # are defined in the profile YAML
                             # files under agent/profiles/.
                             #
-                            # Token metrics are OTLP cumulative
-                            # Sum counters — use max() not +=.
+                            # Token metrics may be OTLP cumulative
+                            # Sum counters or Histograms (pi-otel
+                            # uses histograms). Use max() not +=.
                             if (
                                 name in self._token_metrics
                                 and name not in self._excluded_metrics
                             ):
-                                value = dp.get("asInt") or dp.get("asDouble") or 0
-                                if value:
-                                    int_value = int(value)
-                                    token_type = dp_attrs.get("type", "")
+                                if dp_value:
+                                    int_value = int(dp_value)
+                                    # Claude uses "type", GenAI
+                                    # semconv uses "gen_ai.token.type"
+                                    token_type = (
+                                        dp_attrs.get("type")
+                                        or dp_attrs.get("gen_ai.token.type")
+                                        or ""
+                                    )
                                     if token_type == "input":
                                         tel["input_tokens"] = max(
                                             tel.get("input_tokens", 0),
@@ -1422,7 +1447,10 @@ class HostDaemon:
                                             tel.get("cache_read_tokens", 0),
                                             int_value,
                                         )
-                                    elif token_type in ("cacheCreation", "cache"):
+                                    elif token_type in (
+                                        "cacheCreation",
+                                        "cache",
+                                    ):
                                         tel["cache_creation_tokens"] = max(
                                             tel.get("cache_creation_tokens", 0),
                                             int_value,
@@ -1437,18 +1465,19 @@ class HostDaemon:
 
                             # Cost metrics (cumulative Sum, USD)
                             if name in self._cost_metrics:
-                                value = dp.get("asDouble") or dp.get("asInt") or 0
-                                if value:
+                                if dp_value:
                                     tel["cost_usd"] = max(
                                         tel.get("cost_usd", 0.0),
-                                        float(value),
+                                        float(dp_value),
                                     )
                                     changed = True
 
                             # Activity metrics (tool/function name)
                             if name in self._activity_metrics:
-                                fn = dp_attrs.get("function_name") or dp_attrs.get(
-                                    "tool_name"
+                                fn = (
+                                    dp_attrs.get("function_name")
+                                    or dp_attrs.get("tool_name")
+                                    or dp_attrs.get("gen_ai.tool.name")
                                 )
                                 if fn and isinstance(fn, str):
                                     tel["current_activity"] = fn
@@ -1456,13 +1485,12 @@ class HostDaemon:
 
                             # Runtime duration metrics
                             if name in self._runtime_metrics:
-                                value = dp.get("asInt") or dp.get("asDouble") or 0
-                                if value:
+                                if dp_value:
                                     unit = self._runtime_metrics[name]
                                     if unit == "milliseconds":
-                                        tel["run_time_seconds"] = int(value / 1000)
+                                        tel["run_time_seconds"] = int(dp_value / 1000)
                                     else:
-                                        tel["run_time_seconds"] = int(value)
+                                        tel["run_time_seconds"] = int(dp_value)
                                     changed = True
 
                 if changed:

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1196,6 +1196,8 @@ class HostDaemon:
             tool_hint = "gemini"
         elif "claude" in svc.lower() or "claude" in all_vals:
             tool_hint = "claude"
+        elif "pi" == svc.lower() or "pi-otel" in all_vals:
+            tool_hint = "pi"
 
         if tool_hint:
             candidates = [
@@ -1232,7 +1234,18 @@ class HostDaemon:
         """
         try:
             data = await request.json()
-            log.info(f"OTLP received on {request.path}: " f"{list(data.keys())}")
+            # Identify signal types present in the payload
+            # for clearer logging (especially when requests
+            # arrive on the root-path workaround route).
+            signals = [
+                k.replace("resource", "").lower()
+                for k in data
+                if k.startswith("resource")
+            ]
+            log.info(
+                f"OTLP received on {request.path}"
+                f" signals={signals or list(data.keys())}"
+            )
 
             # Optional verbose debug mode for inspecting
             # raw OTLP payloads from agent tools.
@@ -1472,6 +1485,13 @@ class HostDaemon:
         app.router.add_post("/v1/logs", self.handle_otlp)
         app.router.add_post("/v1/traces", self.handle_otlp)
         app.router.add_post("/v1/metrics", self.handle_otlp)
+        # Workaround for pi-otel (and potentially other OTel
+        # clients) that send HTTP/JSON OTLP to the root path
+        # instead of /v1/{signal}. pi-otel's pickByProtocol
+        # passes cfg.endpoint as the exporter url option,
+        # which bypasses the SDK's signal-path appending.
+        # See: https://github.com/NikiforovAll/pi-otel/issues/4
+        app.router.add_post("/", self.handle_otlp)
         self.otlp_runner = web.AppRunner(app)
         await self.otlp_runner.setup()
         site = web.TCPSite(self.otlp_runner, "127.0.0.1", self.otlp_port)

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -493,7 +493,7 @@ class HostDaemon:
             )
 
     @staticmethod
-    def _remote_to_web_url(remote_url: str) -> str | None:
+    def _remote_to_web_url(remote_url: str) -> Optional[str]:
         """Converts a git remote URL to an HTTPS web URL.
 
         Handles SSH and HTTPS formats:

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1548,7 +1548,11 @@ class HostDaemon:
                             namespace="/terminal",
                         )
 
-            return web.Response(status=200)
+            return web.Response(
+                status=200,
+                body=b"{}",
+                content_type="application/json",
+            )
         except Exception as e:
             log.info(f"OTLP Error: {e}")
             return web.Response(status=400)

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1132,11 +1132,13 @@ class HostDaemon:
 
         # Current activity — extract the latest tool/function
         # name from span or log attributes.  Gemini uses
-        # 'function_name', Claude uses 'tool_name'.
+        # 'function_name', Claude uses 'tool_name', pi-otel
+        # uses 'gen_ai.tool.name'.
         activity = None
         for key in (
             "function_name",
             "tool_name",
+            "gen_ai.tool.name",
             "gen_ai.operation.name",
         ):
             val = attrs.get(key)
@@ -1320,10 +1322,20 @@ class HostDaemon:
                         if self._update_telemetry_from_attrs(tel, attrs):
                             changed = True
 
+                        # Extract activity from span names like
+                        # "pi.tool.bash", "pi.tool.read", etc.
+                        # when attributes didn't provide it.
+                        span_name = span.get("name") or ""
+                        if span_name.startswith("pi.tool."):
+                            tool = span_name[len("pi.tool.") :]
+                            if tool and tel.get("current_activity") != tool:
+                                tel["current_activity"] = tool
+                                changed = True
+
                         # Check span name for permission /
                         # waiting signals (future-proofing for
                         # when tools emit these via OTLP).
-                        span_name = (span.get("name") or "").lower()
+                        span_name = span_name.lower()
                         if any(kw in span_name for kw in _wait_keywords):
                             info = self.agents[agent_id]
                             info["permission_candidate"] = time.monotonic()

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -154,6 +154,11 @@ class HostDaemon:
         self.cached_projects = []
         self.projects_lock = asyncio.Lock()
         self.otlp_runner = None
+        # Event set once the OTLP HTTP server is
+        # listening.  spawn_agent() awaits this so
+        # pi-otel's 300 ms TCP probe at session_start
+        # doesn't race against server startup.
+        self._otlp_ready = asyncio.Event()
 
         @self.sio.on("*", namespace="/terminal")
         async def catch_all(event, data):
@@ -748,6 +753,21 @@ class HostDaemon:
             except Exception:
                 pass
 
+        # Wait for the OTLP receiver to be listening
+        # before spawning the agent process.  pi-otel
+        # probes the endpoint with a 300 ms TCP connect
+        # at session_start; if the server isn't ready the
+        # probe fails and telemetry is silently disabled
+        # for the entire session.
+        try:
+            await asyncio.wait_for(self._otlp_ready.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            log.warning(
+                f"OTLP server not ready after 5 s — "
+                f"agent {agent_id} may not report "
+                f"telemetry"
+            )
+
         log.info(
             f"Spawning agent {agent_id} with tool: {tool} "
             f"mode: {session_mode} in {full_path}"
@@ -1271,8 +1291,8 @@ class HostDaemon:
             # Identify signal types present in the payload
             # for clearer logging (especially when requests
             # arrive on the root-path workaround route).
-            # TODO: Remove signal-sniffing once the root-path
-            # route is removed (see NikiforovAll/pi-otel#6).
+            # Signal-sniffing helps when payloads arrive on
+            # the root-path compatibility route.
             signals = [
                 k.replace("resource", "").lower()
                 for k in data
@@ -1563,24 +1583,19 @@ class HostDaemon:
         app.router.add_post("/v1/logs", self.handle_otlp)
         app.router.add_post("/v1/traces", self.handle_otlp)
         app.router.add_post("/v1/metrics", self.handle_otlp)
-        # Workaround for pi-otel (and potentially other OTel
-        # clients) that send HTTP/JSON OTLP to the root path
-        # instead of /v1/{signal}. pi-otel's pickByProtocol
-        # passes cfg.endpoint as the exporter url option,
-        # which bypasses the SDK's signal-path appending.
-        # See: https://github.com/NikiforovAll/pi-otel/issues/4
-        #
-        # TODO: Remove this route once pi-otel merges the
-        # upstream fix (NikiforovAll/pi-otel#6) and a new
-        # release is published. The local patched copy in
-        # ~/.pi already has the fix, but upstream v0.1.0
-        # still sends to POST /.
+        # Compatibility route: accept OTLP payloads on the
+        # root path for clients that send to the endpoint URL
+        # directly instead of appending /v1/{signal}.  This is
+        # harmless and keeps the receiver resilient regardless
+        # of client implementation details.
+        # History: https://github.com/NikiforovAll/pi-otel/issues/4
         app.router.add_post("/", self.handle_otlp)
         self.otlp_runner = web.AppRunner(app)
         await self.otlp_runner.setup()
         site = web.TCPSite(self.otlp_runner, "127.0.0.1", self.otlp_port)
-        log.info(f"OTLP Receiver listening on " f"http://127.0.0.1:{self.otlp_port}")
         await site.start()
+        self._otlp_ready.set()
+        log.info(f"OTLP Receiver listening on " f"http://127.0.0.1:{self.otlp_port}")
 
     async def update_agent_status(self):
         """Periodically derives agent_status from OTLP and output activity.

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1290,9 +1290,7 @@ class HostDaemon:
             data = await request.json()
             # Identify signal types present in the payload
             # for clearer logging (especially when requests
-            # arrive on the root-path workaround route).
-            # Signal-sniffing helps when payloads arrive on
-            # the root-path compatibility route.
+            # arrive on the root-path compatibility route).
             signals = [
                 k.replace("resource", "").lower()
                 for k in data

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -1,0 +1,63 @@
+# Pi coding agent profile
+# Provider-agnostic terminal coding agent by
+# Mario Zechner. Supports Claude, GPT, Gemini,
+# Grok, and local models (Ollama).
+# https://pi.dev / https://github.com/badlogic/pi-mono
+name: pi
+display_name: Pi
+color: green
+binary: pi
+
+commands:
+  new: ["pi"]
+  resume: ["bash", "-c", "pi --continue || pi"]
+
+# No auth gate — Pi is provider-agnostic and
+# handles its own provider selection and auth.
+# Works with API keys, Vertex AI, or local models.
+
+# No permission_patterns — Pi's design philosophy
+# is "no permission popups" by default.
+
+# No mcp section — Pi uses its own extension system
+# for MCP connectivity (pi-mcp, pre-installed).
+
+# Telemetry via pi-otel extension (pre-installed).
+# Uses OpenTelemetry GenAI semantic conventions.
+# Metric names are best-guess — verify after testing.
+telemetry:
+  token_metrics:
+    - gen_ai.client.token.usage
+  activity_metrics:
+    - pi.tool
+  runtime_metric:
+    name: pi.interaction.duration
+    unit: milliseconds
+
+# Build-time provisioning metadata
+provisioning:
+  install:
+    npm:
+      - "@mariozechner/pi-coding-agent"
+  config_files:
+    - path: "/root/.pi/agent"
+      mkdir: true
+    # Pre-configure pi-otel for HTTP/JSON OTLP
+    # (matching the daemon's receiver protocol)
+    # and disable install telemetry pings.
+    - path: "/root/.pi/agent/settings.json"
+      content: >-
+        {"otel":{"enabled":true,"protocol":"http/json"},
+        "enableInstallTelemetry":false}
+  verify: "pi --version"
+  mounts:
+    - host: "~/.pi"
+      container: "/root/.pi"
+      mode: rw
+  passthrough_env:
+    - ANTHROPIC_API_KEY
+    - OPENAI_API_KEY
+    - GEMINI_API_KEY
+    - GOOGLE_CLOUD_PROJECT
+    - GOOGLE_CLOUD_LOCATION
+    - GOOGLE_APPLICATION_CREDENTIALS

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -38,7 +38,7 @@ telemetry:
 provisioning:
   install:
     npm:
-      - "@mariozechner/pi-coding-agent"
+      - "@earendil-works/pi-coding-agent"
   config_files:
     - path: "/root/.pi/agent"
       mkdir: true

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -12,12 +12,18 @@ commands:
   new: ["pi"]
   resume: ["bash", "-c", "pi --continue || pi"]
 
-# Force OTLP HTTP/JSON protocol for pi-otel to match
-# the daemon's receiver. Without this, pi-otel may
-# default to protobuf encoding which our receiver
-# can't parse.
+# Force OTLP HTTP/JSON protocol for all signals.
+# pi-otel uses separate exporters per signal and may
+# default to gRPC for traces/metrics even when the
+# global protocol is set to http/json. The per-signal
+# env vars ensure all three signals use HTTP/JSON
+# paths (/v1/traces, /v1/metrics, /v1/logs) that our
+# daemon's OTLP receiver handles.
 env:
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/json"
+  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: "http/json"
+  OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: "http/json"
+  OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: "http/json"
 
 # No auth gate — Pi is provider-agnostic and
 # handles its own provider selection and auth.

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -12,18 +12,14 @@ commands:
   new: ["pi"]
   resume: ["bash", "-c", "pi --continue || pi"]
 
-# Force OTLP HTTP/JSON protocol for all signals.
-# pi-otel uses separate exporters per signal and may
-# default to gRPC for traces/metrics even when the
-# global protocol is set to http/json. The per-signal
-# env vars ensure all three signals use HTTP/JSON
-# paths (/v1/traces, /v1/metrics, /v1/logs) that our
-# daemon's OTLP receiver handles.
+# Set OTLP HTTP/JSON protocol for pi-otel. The
+# daemon's OTLP receiver accepts HTTP/JSON on port
+# 4318. Note: due to a bug in pi-otel v0.1.0
+# (NikiforovAll/pi-otel#4), HTTP exporters send to
+# POST / instead of /v1/{signal} — the daemon has a
+# root-path workaround for this.
 env:
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/json"
-  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: "http/json"
-  OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: "http/json"
-  OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: "http/json"
 
 # No auth gate — Pi is provider-agnostic and
 # handles its own provider selection and auth.

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -16,8 +16,10 @@ commands:
 # daemon's OTLP receiver accepts HTTP/JSON on port
 # 4318. Note: due to a bug in pi-otel v0.1.0
 # (NikiforovAll/pi-otel#4), HTTP exporters send to
-# POST / instead of /v1/{signal} — the daemon has a
-# root-path workaround for this.
+# POST / instead of /v1/{signal}. A fix has been
+# submitted upstream (NikiforovAll/pi-otel#6). Once
+# merged and released, remove the daemon's root-path
+# workaround route in start_otlp_server().
 #
 # OTEL_SERVICE_NAME must be set explicitly because
 # pi-otel reads it with higher priority than

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -34,16 +34,18 @@ env:
 # Telemetry requires the pi-otel extension.
 # Install inside a Pi session:
 #   pi install npm:pi-otel
-# Uses OpenTelemetry GenAI semantic conventions.
-# Metric names are best-guess — verify after testing.
+# Metric names from pi-otel v0.1.0 source
+# (dist/otel/metrics.js). Token usage is a
+# histogram — the daemon extracts the cumulative
+# sum from histogram data points.
 telemetry:
   token_metrics:
     - gen_ai.client.token.usage
   activity_metrics:
-    - pi.tool
+    - gen_ai.client.tool.calls
   runtime_metric:
-    name: pi.interaction.duration
-    unit: milliseconds
+    name: gen_ai.client.operation.duration
+    unit: seconds
 
 # Build-time provisioning metadata
 provisioning:

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -12,6 +12,13 @@ commands:
   new: ["pi"]
   resume: ["bash", "-c", "pi --continue || pi"]
 
+# Force OTLP HTTP/JSON protocol for pi-otel to match
+# the daemon's receiver. Without this, pi-otel may
+# default to protobuf encoding which our receiver
+# can't parse.
+env:
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/json"
+
 # No auth gate — Pi is provider-agnostic and
 # handles its own provider selection and auth.
 # Works with API keys, Vertex AI, or local models.

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -18,8 +18,26 @@ commands:
 # (NikiforovAll/pi-otel#4), HTTP exporters send to
 # POST / instead of /v1/{signal} — the daemon has a
 # root-path workaround for this.
+#
+# OTEL_SERVICE_NAME must be set explicitly because
+# pi-otel reads it with higher priority than
+# OTEL_RESOURCE_ATTRIBUTES. Without it, all Pi
+# sessions report service.name="pi" (the default in
+# pi-otel's config.js) and multi-instance tracking
+# breaks — the daemon can't distinguish which Pi
+# session emitted a given metric or span.
+#
+# PI_OTEL_METRICS enables the PeriodicExporting
+# MetricReader in the OTel SDK. Metrics are disabled
+# by default in pi-otel — without this flag, the
+# token_metrics, activity_metrics, and runtime_metric
+# defined below are never emitted. Token tracking
+# partially falls back to span attributes, but the
+# activity counter and duration histogram are lost.
 env:
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/json"
+  OTEL_SERVICE_NAME: "{agent_id}"
+  PI_OTEL_METRICS: "1"
 
 # No auth gate — Pi is provider-agnostic and
 # handles its own provider selection and auth.
@@ -61,9 +79,24 @@ provisioning:
       container: "/root/.pi"
       mode: rw
   passthrough_env:
+    # Core providers
     - ANTHROPIC_API_KEY
     - OPENAI_API_KEY
     - GEMINI_API_KEY
+    # Google Cloud / Vertex AI
     - GOOGLE_CLOUD_PROJECT
     - GOOGLE_CLOUD_LOCATION
     - GOOGLE_APPLICATION_CREDENTIALS
+    # Additional providers — optional, only needed
+    # when using Pi with these specific backends.
+    - XAI_API_KEY
+    - GROQ_API_KEY
+    - DEEPSEEK_API_KEY
+    - AZURE_OPENAI_API_KEY
+    - AZURE_OPENAI_BASE_URL
+    # Amazon Bedrock
+    - AWS_PROFILE
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_BEARER_TOKEN_BEDROCK
+    - AWS_REGION

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -14,12 +14,9 @@ commands:
 
 # Set OTLP HTTP/JSON protocol for pi-otel. The
 # daemon's OTLP receiver accepts HTTP/JSON on port
-# 4318. Note: due to a bug in pi-otel v0.1.0
-# (NikiforovAll/pi-otel#4), HTTP exporters send to
-# POST / instead of /v1/{signal}. A fix has been
-# submitted upstream (NikiforovAll/pi-otel#6). Once
-# merged and released, remove the daemon's root-path
-# workaround route in start_otlp_server().
+# 4318 and includes a root-path compatibility route
+# for clients that don't append /v1/{signal}.
+# History: NikiforovAll/pi-otel#4, #6.
 #
 # OTEL_SERVICE_NAME must be set explicitly because
 # pi-otel reads it with higher priority than

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -19,10 +19,12 @@ commands:
 # No permission_patterns — Pi's design philosophy
 # is "no permission popups" by default.
 
-# No mcp section — Pi uses its own extension system
-# for MCP connectivity (pi-mcp, pre-installed).
+# No mcp section — Pi uses its own extension system.
+# See "Recommended Pi Extensions" in docs/agent-profiles.md.
 
-# Telemetry via pi-otel extension (pre-installed).
+# Telemetry requires the pi-otel extension.
+# Install inside a Pi session:
+#   pi install npm:pi-otel
 # Uses OpenTelemetry GenAI semantic conventions.
 # Metric names are best-guess — verify after testing.
 telemetry:
@@ -42,13 +44,6 @@ provisioning:
   config_files:
     - path: "/root/.pi/agent"
       mkdir: true
-    # Pre-configure pi-otel for HTTP/JSON OTLP
-    # (matching the daemon's receiver protocol)
-    # and disable install telemetry pings.
-    - path: "/root/.pi/agent/settings.json"
-      content: >-
-        {"otel":{"enabled":true,"protocol":"http/json"},
-        "enableInstallTelemetry":false}
   verify: "pi --version"
   mounts:
     - host: "~/.pi"

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -568,6 +568,23 @@ class TestAgentProfiles:
         # Bash has no provisioning
         assert profiles["bash"].provisioning is None
 
+    def test_pi_profile_fields(self):
+        """Pi profile has expected configuration."""
+        from agent.profiles import load_profiles
+
+        profiles = load_profiles()
+        pi = profiles["pi"]
+        assert pi.binary == "pi"
+        assert pi.display_name == "Pi"
+        assert pi.color == "green"
+        assert pi.commands.new == ["pi"]
+        assert pi.supports_resume is True
+        assert pi.auth.env_vars == []
+        assert pi.provisioning is not None
+        assert "@mariozechner/pi-coding-agent" in pi.provisioning.install.npm
+        assert pi.provisioning.verify == "pi --version"
+        assert any(m.host == "~/.pi" for m in pi.provisioning.mounts)
+
     def test_unknown_profile_returns_empty(self):
         """Loading from empty directory returns no profiles."""
         import tempfile

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -581,7 +581,7 @@ class TestAgentProfiles:
         assert pi.supports_resume is True
         assert pi.auth.env_vars == []
         assert pi.provisioning is not None
-        assert "@mariozechner/pi-coding-agent" in pi.provisioning.install.npm
+        assert "@earendil-works/pi-coding-agent" in pi.provisioning.install.npm
         assert pi.provisioning.verify == "pi --version"
         assert any(m.host == "~/.pi" for m in pi.provisioning.mounts)
 

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -301,6 +301,57 @@ class TestResolveAgentId:
         result = daemon._resolve_agent_id({"service.name": "unknown"})
         assert result is None
 
+    def test_pi_fallback_service_name_pi(self, daemon):
+        """Pi tool hint when service.name is exactly 'pi'.
+
+        pi-otel defaults service.name to 'pi' when
+        OTEL_SERVICE_NAME is not set. The daemon's
+        fallback logic must still route telemetry to
+        the correct Pi agent session.
+        """
+        daemon.agents["pi-1"] = {
+            "tool": "pi",
+            "last_output_time": 1.0,
+        }
+        result = daemon._resolve_agent_id({"service.name": "pi"})
+        assert result == "pi-1"
+
+    def test_pi_fallback_pi_otel_in_values(self, daemon):
+        """Pi tool hint from 'pi-otel' in resource attribute
+        values (e.g. telemetry.sdk.name or similar)."""
+        daemon.agents["pi-2"] = {
+            "tool": "pi",
+            "last_output_time": 1.0,
+        }
+        result = daemon._resolve_agent_id(
+            {"service.name": "unknown", "telemetry.sdk.name": "pi-otel"}
+        )
+        assert result == "pi-2"
+
+    def test_pi_fallback_multiple_candidates(self, daemon):
+        """Multiple Pi agents: picks most recent output."""
+        daemon.agents["pi-old"] = {
+            "tool": "pi",
+            "last_output_time": 1.0,
+        }
+        daemon.agents["pi-new"] = {
+            "tool": "pi",
+            "last_output_time": 99.0,
+        }
+        result = daemon._resolve_agent_id({"service.name": "pi"})
+        assert result == "pi-new"
+
+    def test_pi_direct_match_with_otel_service_name(self, daemon):
+        """When OTEL_SERVICE_NAME is set to the agent_id,
+        pi-otel sends the agent_id as service.name and
+        the daemon matches directly without fallback."""
+        daemon.agents["pi-abc12345"] = {
+            "tool": "pi",
+            "last_output_time": 1.0,
+        }
+        result = daemon._resolve_agent_id({"service.name": "pi-abc12345"})
+        assert result == "pi-abc12345"
+
 
 # ── E. get_git_info ──────────────────────────────────────────
 
@@ -584,6 +635,58 @@ class TestAgentProfiles:
         assert "@earendil-works/pi-coding-agent" in pi.provisioning.install.npm
         assert pi.provisioning.verify == "pi --version"
         assert any(m.host == "~/.pi" for m in pi.provisioning.mounts)
+
+    def test_pi_profile_otel_env_vars(self):
+        """Pi profile sets OTEL_SERVICE_NAME and
+        PI_OTEL_METRICS for correct multi-instance
+        tracking and metric emission."""
+        from agent.profiles import load_profiles
+
+        profiles = load_profiles()
+        pi = profiles["pi"]
+        # OTEL_SERVICE_NAME must use {agent_id} placeholder
+        # so pi-otel reports the agent's unique ID instead
+        # of the default "pi".
+        assert "OTEL_SERVICE_NAME" in pi.env
+        assert "{agent_id}" in pi.env["OTEL_SERVICE_NAME"]
+        # PI_OTEL_METRICS must be "1" to enable the
+        # PeriodicExportingMetricReader in pi-otel's SDK.
+        assert pi.env.get("PI_OTEL_METRICS") == "1"
+        # OTLP protocol must be http/json for the daemon's
+        # HTTP receiver.
+        assert pi.env.get("OTEL_EXPORTER_OTLP_PROTOCOL") == "http/json"
+
+    def test_pi_profile_passthrough_env(self):
+        """Pi profile passes through env vars for core
+        and additional providers."""
+        from agent.profiles import load_profiles
+
+        profiles = load_profiles()
+        penv = profiles["pi"].provisioning.passthrough_env
+        # Core providers
+        assert "ANTHROPIC_API_KEY" in penv
+        assert "OPENAI_API_KEY" in penv
+        assert "GEMINI_API_KEY" in penv
+        # Google Cloud / Vertex AI
+        assert "GOOGLE_CLOUD_PROJECT" in penv
+        assert "GOOGLE_CLOUD_LOCATION" in penv
+        # Additional providers
+        assert "XAI_API_KEY" in penv
+        assert "GROQ_API_KEY" in penv
+        assert "DEEPSEEK_API_KEY" in penv
+        assert "AZURE_OPENAI_API_KEY" in penv
+        # Amazon Bedrock
+        assert "AWS_ACCESS_KEY_ID" in penv
+        assert "AWS_SECRET_ACCESS_KEY" in penv
+        assert "AWS_REGION" in penv
+
+    def test_pi_telemetry_metrics_in_lookup_tables(self, daemon):
+        """Pi's telemetry metrics are registered in the
+        daemon's OTLP lookup tables."""
+        assert "gen_ai.client.token.usage" in daemon._token_metrics
+        assert "gen_ai.client.tool.calls" in daemon._activity_metrics
+        assert "gen_ai.client.operation.duration" in daemon._runtime_metrics
+        assert daemon._runtime_metrics["gen_ai.client.operation.duration"] == "seconds"
 
     def test_unknown_profile_returns_empty(self):
         """Loading from empty directory returns no profiles."""

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -14,6 +14,7 @@ Four profiles are included out of the box:
 |---------|------|-------------|
 | Claude | `agent/profiles/claude.yaml` | Claude Code CLI with OTLP telemetry and MCP detection |
 | Antigravity | `agent/profiles/agy.yaml` | Antigravity CLI (`agy`) — Google's replacement for Gemini CLI |
+| Pi | `agent/profiles/pi.yaml` | Pi coding agent — provider-agnostic, supports Claude/GPT/Gemini/local models |
 | Gemini | `agent/profiles/gemini.yaml` | Gemini CLI (sunset June 18, 2026 — replaced by Antigravity) |
 | Bash | `agent/profiles/bash.yaml` | Bash shell with PROMPT_COMMAND sidecar telemetry |
 
@@ -462,6 +463,49 @@ After June 18, 2026, free/personal users can remove
 `agent/profiles/gemini.yaml` and regenerate the
 Containerfile to drop Gemini CLI from the container
 image.
+
+## Bundled Pi Extensions
+
+The Pi coding agent uses a community extension system
+for telemetry, cloud providers, and MCP connectivity.
+Three extensions are pre-installed in the daemon
+container. Each was selected for being the most
+complete and actively maintained option in its
+category as of June 2026.
+
+Users can replace, remove, or add extensions via
+`pi install` / `pi uninstall` inside a session, or by
+editing `~/.pi/agent/settings.json` (persisted via the
+`~/.pi` volume mount).
+
+| Extension | Package | Purpose |
+|-----------|---------|---------|
+| [pi-otel](https://www.npmjs.com/package/pi-otel) | `npm:pi-otel` | OTLP telemetry for dashboard cards (traces, metrics, logs). The only OTel extension for Pi. |
+| [pi-vertex](https://pi.dev/packages/@ssweens/pi-vertex) | `npm:@ssweens/pi-vertex` | Vertex AI provider for Claude and Gemini models via Google Cloud. Supports gcloud ADC auth and cost tracking. |
+| [pi-mcp](https://github.com/0xKobold/pi-mcp) | `npm:@0xkobold/pi-mcp` | MCP server connectivity. Supports stdio, SSE, HTTP, and WebSocket transports. Auto-discovers tools with allowlist/denylist filtering. |
+
+### Replacing an extension
+
+These are community-maintained packages. If a better
+alternative emerges or one becomes unmaintained, replace
+it in `agent/Containerfile.template` (the `pi install`
+line) and update this documentation. The profile YAML
+itself doesn't reference extensions — they're installed
+at container build time and configured via settings
+files in the mounted `~/.pi` directory.
+
+### Extension configuration
+
+- **pi-otel**: Pre-configured in the seeded
+  `settings.json` for HTTP/JSON protocol. The daemon
+  injects `OTEL_EXPORTER_OTLP_ENDPOINT` at spawn time.
+- **pi-vertex**: Uses `GOOGLE_CLOUD_PROJECT`,
+  `GOOGLE_CLOUD_LOCATION`, and gcloud ADC credentials
+  (mounted via `~/.config/gcloud`). Launch with
+  `pi --provider vertex --model claude-sonnet-4-6`.
+- **pi-mcp**: Reads server configs from
+  `~/.pi/agent/mcp.json`. Can import configs from
+  Claude Code, Cursor, and VS Code.
 
 ## Known Limitations
 

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -616,14 +616,18 @@ If you need to connect to such services, set
 `NODE_TLS_REJECT_UNAUTHORIZED=0` in the agent's
 environment.
 
-You can add it to the Pi profile's `env` section:
+The recommended approach is a [local override](#local-overrides)
+so you don't modify the tracked profile:
 
 ```yaml
+# agent/profiles/pi.local.yaml
+name: pi
 env:
   NODE_TLS_REJECT_UNAUTHORIZED: "0"
 ```
 
-Or pass it through to the container at runtime:
+Alternatively, pass it through to the container at
+runtime:
 
 ```bash
 -e NODE_TLS_REJECT_UNAUTHORIZED=0    # podman run

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -607,6 +607,37 @@ extension.
 
 ## Known Limitations
 
+### Self-signed TLS certificates
+
+Pi (and other Node.js-based agents like Claude Code and
+Gemini CLI) will reject connections to MCP servers or
+other services that use self-signed TLS certificates.
+If you need to connect to such services, set
+`NODE_TLS_REJECT_UNAUTHORIZED=0` in the agent's
+environment.
+
+You can add it to the Pi profile's `env` section:
+
+```yaml
+env:
+  NODE_TLS_REJECT_UNAUTHORIZED: "0"
+```
+
+Or pass it through to the container at runtime:
+
+```bash
+-e NODE_TLS_REJECT_UNAUTHORIZED=0    # podman run
+Environment=NODE_TLS_REJECT_UNAUTHORIZED=0  # quadlet
+```
+
+> **Security note:** This disables TLS certificate
+> verification for all outbound HTTPS connections in
+> that agent process, not just the MCP server. Only
+> use this in environments where you trust the network
+> (e.g., internal development networks with a private
+> CA). The preferred solution is to install your CA
+> certificate in the container's trust store.
+
 ### Session resume path mismatch
 
 Claude Code keys project history by **absolute CWD path**.

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -477,7 +477,7 @@ Install the following inside a Pi session on first use:
 
 | Extension | Install Command | Purpose |
 |-----------|----------------|---------|
-| [pi-otel](https://www.npmjs.com/package/pi-otel) | `pi install npm:pi-otel` | OTLP telemetry for dashboard cards (traces, metrics, logs). Enables token usage, cost, and activity on agent cards. |
+| [pi-otel](https://www.npmjs.com/package/pi-otel) | `pi install npm:pi-otel` | OTLP telemetry for dashboard cards. Enables agent status and tool activity tracking. Model and token data pending upstream fixes (see below). |
 | [pi-mcp](https://github.com/0xKobold/pi-mcp) | `pi install npm:@0xkobold/pi-mcp` | MCP server connectivity. Supports stdio, SSE, HTTP, and WebSocket transports. |
 
 Or install both at once:
@@ -509,11 +509,20 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp
   settings.json or via `PI_OTEL_METRICS=1` and
   `PI_OTEL_LOGS=1` env vars.
 
-  > **Known issue (pi-otel v0.1.0):** HTTP exporters
-  > send to `POST /` instead of `/v1/{signal}` paths
-  > due to a [URL construction bug](https://github.com/NikiforovAll/pi-otel/issues/4).
-  > The daemon includes a root-path workaround that
-  > auto-detects the signal type from the payload.
+  > **Known issues (pi-otel v0.1.0):**
+  >
+  > - HTTP exporters send to `POST /` instead of
+  >   `/v1/{signal}` paths due to a
+  >   [URL construction bug](https://github.com/NikiforovAll/pi-otel/issues/4).
+  >   The daemon includes a root-path workaround that
+  >   auto-detects the signal type from the payload.
+  > - `pi.llm_request` spans are
+  >   [not emitted](https://github.com/NikiforovAll/pi-otel/issues/5),
+  >   so **model name, token usage, and cost are not
+  >   available**. Agent status and tool activity
+  >   (e.g., "bash", "read") work correctly. Model
+  >   and token tracking will work once this is fixed
+  >   upstream — no daemon changes needed.
 - **pi-mcp**: Reads server configs from
   `~/.pi/agent/mcp.json`. Can import configs from
   Claude Code, Cursor, and VS Code.

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -477,7 +477,7 @@ Install the following inside a Pi session on first use:
 
 | Extension | Install Command | Purpose |
 |-----------|----------------|---------|
-| [pi-otel](https://www.npmjs.com/package/pi-otel) | `pi install npm:pi-otel` | OTLP telemetry for dashboard cards. Enables agent status and tool activity tracking. Model and token data pending upstream fixes (see below). |
+| [pi-otel](https://www.npmjs.com/package/pi-otel) | `pi install npm:pi-otel` | OTLP telemetry for dashboard cards (model, tokens, cost, activity). |
 | [pi-mcp](https://github.com/0xKobold/pi-mcp) | `pi install npm:@0xkobold/pi-mcp` | MCP server connectivity. Supports stdio, SSE, HTTP, and WebSocket transports. |
 
 Or install both at once:
@@ -509,20 +509,12 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp
   settings.json or via `PI_OTEL_METRICS=1` and
   `PI_OTEL_LOGS=1` env vars.
 
-  > **Known issues (pi-otel v0.1.0):**
-  >
-  > - HTTP exporters send to `POST /` instead of
-  >   `/v1/{signal}` paths due to a
-  >   [URL construction bug](https://github.com/NikiforovAll/pi-otel/issues/4).
-  >   The daemon includes a root-path workaround that
-  >   auto-detects the signal type from the payload.
-  > - `pi.llm_request` spans are
-  >   [not emitted](https://github.com/NikiforovAll/pi-otel/issues/5),
-  >   so **model name, token usage, and cost are not
-  >   available**. Agent status and tool activity
-  >   (e.g., "bash", "read") work correctly. Model
-  >   and token tracking will work once this is fixed
-  >   upstream — no daemon changes needed.
+  > **Known issue (pi-otel v0.1.0):** HTTP exporters
+  > send to `POST /` instead of `/v1/{signal}` paths
+  > due to a
+  > [URL construction bug](https://github.com/NikiforovAll/pi-otel/issues/4).
+  > The daemon includes a root-path workaround that
+  > auto-detects the signal type from the payload.
 - **pi-mcp**: Reads server configs from
   `~/.pi/agent/mcp.json`. Can import configs from
   Claude Code, Cursor, and VS Code.

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -466,29 +466,24 @@ image.
 
 ## Recommended Pi Extensions
 
-Pi uses community extensions for telemetry, cloud
-providers, and MCP connectivity. Extensions are
-installed per-user inside a Pi session and persist
-via the `~/.pi` volume mount. They cannot be
-pre-installed in the container image because the host
-volume mount overlays the container's `/root/.pi`
-directory at runtime.
+Pi uses community extensions for telemetry and MCP
+connectivity. Extensions are installed per-user inside
+a Pi session and persist via the `~/.pi` volume mount.
+They cannot be pre-installed in the container image
+because the host volume mount overlays the container's
+`/root/.pi` directory at runtime.
 
-Install the following extensions inside a Pi session
-on first use. Each was selected as the most complete
-and actively maintained option in its category as of
-June 2026.
+Install the following inside a Pi session on first use:
 
 | Extension | Install Command | Purpose |
 |-----------|----------------|---------|
 | [pi-otel](https://www.npmjs.com/package/pi-otel) | `pi install npm:pi-otel` | OTLP telemetry for dashboard cards (traces, metrics, logs). Enables token usage, cost, and activity on agent cards. |
-| [pi-vertex](https://pi.dev/packages/@ssweens/pi-vertex) | `pi install npm:@ssweens/pi-vertex` | Vertex AI provider for Claude and Gemini models via Google Cloud. Use `/login` to configure after installing. |
 | [pi-mcp](https://github.com/0xKobold/pi-mcp) | `pi install npm:@0xkobold/pi-mcp` | MCP server connectivity. Supports stdio, SSE, HTTP, and WebSocket transports. |
 
-Or install all three at once:
+Or install both at once:
 
 ```
-pi install npm:pi-otel npm:@ssweens/pi-vertex npm:@0xkobold/pi-mcp
+pi install npm:pi-otel npm:@0xkobold/pi-mcp
 ```
 
 ### Extension configuration
@@ -500,13 +495,37 @@ pi install npm:pi-otel npm:@ssweens/pi-vertex npm:@0xkobold/pi-mcp
   ```
   The daemon injects `OTEL_EXPORTER_OTLP_ENDPOINT` at
   spawn time, which pi-otel respects.
-- **pi-vertex**: After installing, run `/login` inside
-  a Pi session and select "Google Vertex AI". Uses
-  `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and
-  gcloud ADC credentials (mounted via `~/.config/gcloud`).
 - **pi-mcp**: Reads server configs from
   `~/.pi/agent/mcp.json`. Can import configs from
   Claude Code, Cursor, and VS Code.
+
+### Using Pi with Vertex AI
+
+Pi supports Claude and Gemini models via Google Cloud
+Vertex AI through the `@ssweens/pi-vertex` extension.
+Install it inside a Pi session:
+
+```
+pi install npm:@ssweens/pi-vertex
+```
+
+Vertex AI requires `--provider vertex` at launch time.
+Edit `agent/profiles/pi.yaml` to add the flag:
+
+```yaml
+commands:
+  new: ["pi", "--provider", "vertex"]
+  resume: ["bash", "-c",
+    "pi --provider vertex --continue || pi --provider vertex"]
+```
+
+You also need `GOOGLE_CLOUD_PROJECT` and gcloud ADC
+credentials (`~/.config/gcloud` mount) configured in
+your quadlet.
+
+> **Note:** A built-in Vertex AI provider for Pi is
+> [proposed upstream](https://github.com/earendil-works/pi/issues/5082),
+> which would eliminate the need for this extension.
 
 ### Replacing an extension
 

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -488,8 +488,32 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp
 
 ### Extension configuration
 
-- **pi-otel**: After installing, configure OTLP settings
-  in `~/.pi/agent/settings.json`:
+- **pi-otel**: The Pi profile injects the essential
+  OTLP environment variables at spawn time:
+  - `OTEL_EXPORTER_OTLP_ENDPOINT` — set by the daemon
+    to `http://127.0.0.1:{otlp_port}` for all tools.
+  - `OTEL_EXPORTER_OTLP_PROTOCOL` — set to `http/json`
+    so pi-otel uses the daemon's HTTP/JSON receiver.
+  - `OTEL_SERVICE_NAME` — set to the agent's unique ID
+    so the daemon can match OTLP data to the correct
+    session. **This is required for multi-instance
+    tracking.** Pi-otel reads `OTEL_SERVICE_NAME` with
+    higher priority than `OTEL_RESOURCE_ATTRIBUTES` —
+    without it, all Pi sessions report
+    `service.name="pi"` (the default) and the daemon
+    cannot distinguish between them.
+  - `PI_OTEL_METRICS` — set to `1` to enable the
+    `PeriodicExportingMetricReader` in the OTel SDK.
+    **Metrics are disabled by default in pi-otel.** Without
+    this, the token usage histogram, tool call counter,
+    and operation duration histogram defined in the Pi
+    profile's `telemetry` section are never emitted.
+    Token tracking partially falls back to span
+    attributes, but the activity counter and runtime
+    histogram are lost.
+
+  You can optionally configure additional settings in
+  `~/.pi/agent/settings.json`:
   ```json
   {
     "otel": {
@@ -503,11 +527,11 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp
     }
   }
   ```
-  The daemon injects `OTEL_EXPORTER_OTLP_ENDPOINT` at
-  spawn time, which pi-otel respects. Metrics and logs
-  signals are disabled by default — enable them in
-  settings.json or via `PI_OTEL_METRICS=1` and
-  `PI_OTEL_LOGS=1` env vars.
+  The profile's env vars take precedence over
+  settings.json for the values they set. The `logs`
+  signal can be enabled via `PI_OTEL_LOGS=1` env var
+  or in settings.json — it forwards OTel internal
+  diagnostics to the OTLP endpoint.
 
   > **Known issue (pi-otel v0.1.0):** HTTP exporters
   > send to `POST /` instead of `/v1/{signal}` paths
@@ -602,6 +626,11 @@ so the CWD is identical in both environments.
 - The standard OTLP endpoint and resource attributes
   (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_RESOURCE_ATTRIBUTES`)
   are always injected by the daemon regardless of profile.
+- Some OTel SDKs (notably pi-otel) read `OTEL_SERVICE_NAME`
+  with higher priority than the `service.name` key in
+  `OTEL_RESOURCE_ATTRIBUTES`. Profiles for such tools
+  should set `OTEL_SERVICE_NAME: "{agent_id}"` in their
+  `env` section to ensure correct multi-instance tracking.
 - Generic permission patterns (Y/n, yes/no, Continue?, etc.)
   are always active. Profile patterns are merged in addition.
 - Profile changes require a daemon restart to take effect.

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -533,14 +533,13 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp
   or in settings.json — it forwards OTel internal
   diagnostics to the OTLP endpoint.
 
-  > **Known issue (pi-otel v0.1.0):** HTTP exporters
+  > **Note (pi-otel v0.1.0):** HTTP exporters may
   > send to `POST /` instead of `/v1/{signal}` paths
-  > due to a
-  > [URL construction bug](https://github.com/NikiforovAll/pi-otel/issues/4).
-  > A [fix has been submitted](https://github.com/NikiforovAll/pi-otel/pull/6)
-  > upstream. The daemon includes a root-path
-  > workaround that auto-detects the signal type from
-  > the payload — remove it once the fix is released.
+  > ([details](https://github.com/NikiforovAll/pi-otel/issues/4)).
+  > The daemon includes a permanent root-path
+  > compatibility route that auto-detects the signal
+  > type from the payload, so this is handled
+  > transparently.
 - **pi-mcp**: Reads server configs from
   `~/.pi/agent/mcp.json`. Can import configs from
   Claude Code, Cursor, and VS Code.

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -519,9 +519,27 @@ commands:
     "pi --provider vertex --continue || pi --provider vertex"]
 ```
 
-You also need `GOOGLE_CLOUD_PROJECT` and gcloud ADC
-credentials (`~/.config/gcloud` mount) configured in
-your quadlet.
+You also need the following in your daemon quadlet or
+`podman run` command:
+
+```ini
+# Pi-vertex uses different env var names than Claude Code.
+# If you already have ANTHROPIC_VERTEX_PROJECT_ID and
+# CLOUD_ML_REGION for Claude Code, add these with the
+# same values:
+Environment=GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+Environment=GOOGLE_CLOUD_LOCATION=us-east5
+```
+
+| Claude Code env var | Pi-vertex equivalent |
+|---|---|
+| `ANTHROPIC_VERTEX_PROJECT_ID` | `GOOGLE_CLOUD_PROJECT` |
+| `CLOUD_ML_REGION` | `GOOGLE_CLOUD_LOCATION` |
+| `CLAUDE_CODE_USE_VERTEX` | (not used by Pi) |
+
+The gcloud ADC credentials (`~/.config/gcloud` mount)
+handle authentication for both Claude Code and Pi — no
+additional credential setup needed.
 
 > **Note:** A built-in Vertex AI provider for Pi is
 > [proposed upstream](https://github.com/earendil-works/pi/issues/5082),

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -537,8 +537,10 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp
   > send to `POST /` instead of `/v1/{signal}` paths
   > due to a
   > [URL construction bug](https://github.com/NikiforovAll/pi-otel/issues/4).
-  > The daemon includes a root-path workaround that
-  > auto-detects the signal type from the payload.
+  > A [fix has been submitted](https://github.com/NikiforovAll/pi-otel/pull/6)
+  > upstream. The daemon includes a root-path
+  > workaround that auto-detects the signal type from
+  > the payload — remove it once the fix is released.
 - **pi-mcp**: Reads server configs from
   `~/.pi/agent/mcp.json`. Can import configs from
   Claude Code, Cursor, and VS Code.

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -491,10 +491,29 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp
 - **pi-otel**: After installing, configure OTLP settings
   in `~/.pi/agent/settings.json`:
   ```json
-  {"otel": {"enabled": true, "protocol": "http/json"}}
+  {
+    "otel": {
+      "enabled": true,
+      "protocol": "http/json",
+      "signals": {
+        "traces": true,
+        "metrics": true,
+        "logs": true
+      }
+    }
+  }
   ```
   The daemon injects `OTEL_EXPORTER_OTLP_ENDPOINT` at
-  spawn time, which pi-otel respects.
+  spawn time, which pi-otel respects. Metrics and logs
+  signals are disabled by default — enable them in
+  settings.json or via `PI_OTEL_METRICS=1` and
+  `PI_OTEL_LOGS=1` env vars.
+
+  > **Known issue (pi-otel v0.1.0):** HTTP exporters
+  > send to `POST /` instead of `/v1/{signal}` paths
+  > due to a [URL construction bug](https://github.com/NikiforovAll/pi-otel/issues/4).
+  > The daemon includes a root-path workaround that
+  > auto-detects the signal type from the payload.
 - **pi-mcp**: Reads server configs from
   `~/.pi/agent/mcp.json`. Can import configs from
   Claude Code, Cursor, and VS Code.

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -464,48 +464,57 @@ After June 18, 2026, free/personal users can remove
 Containerfile to drop Gemini CLI from the container
 image.
 
-## Bundled Pi Extensions
+## Recommended Pi Extensions
 
-The Pi coding agent uses a community extension system
-for telemetry, cloud providers, and MCP connectivity.
-Three extensions are pre-installed in the daemon
-container. Each was selected for being the most
-complete and actively maintained option in its
-category as of June 2026.
+Pi uses community extensions for telemetry, cloud
+providers, and MCP connectivity. Extensions are
+installed per-user inside a Pi session and persist
+via the `~/.pi` volume mount. They cannot be
+pre-installed in the container image because the host
+volume mount overlays the container's `/root/.pi`
+directory at runtime.
 
-Users can replace, remove, or add extensions via
-`pi install` / `pi uninstall` inside a session, or by
-editing `~/.pi/agent/settings.json` (persisted via the
-`~/.pi` volume mount).
+Install the following extensions inside a Pi session
+on first use. Each was selected as the most complete
+and actively maintained option in its category as of
+June 2026.
 
-| Extension | Package | Purpose |
-|-----------|---------|---------|
-| [pi-otel](https://www.npmjs.com/package/pi-otel) | `npm:pi-otel` | OTLP telemetry for dashboard cards (traces, metrics, logs). The only OTel extension for Pi. |
-| [pi-vertex](https://pi.dev/packages/@ssweens/pi-vertex) | `npm:@ssweens/pi-vertex` | Vertex AI provider for Claude and Gemini models via Google Cloud. Supports gcloud ADC auth and cost tracking. |
-| [pi-mcp](https://github.com/0xKobold/pi-mcp) | `npm:@0xkobold/pi-mcp` | MCP server connectivity. Supports stdio, SSE, HTTP, and WebSocket transports. Auto-discovers tools with allowlist/denylist filtering. |
+| Extension | Install Command | Purpose |
+|-----------|----------------|---------|
+| [pi-otel](https://www.npmjs.com/package/pi-otel) | `pi install npm:pi-otel` | OTLP telemetry for dashboard cards (traces, metrics, logs). Enables token usage, cost, and activity on agent cards. |
+| [pi-vertex](https://pi.dev/packages/@ssweens/pi-vertex) | `pi install npm:@ssweens/pi-vertex` | Vertex AI provider for Claude and Gemini models via Google Cloud. Use `/login` to configure after installing. |
+| [pi-mcp](https://github.com/0xKobold/pi-mcp) | `pi install npm:@0xkobold/pi-mcp` | MCP server connectivity. Supports stdio, SSE, HTTP, and WebSocket transports. |
+
+Or install all three at once:
+
+```
+pi install npm:pi-otel npm:@ssweens/pi-vertex npm:@0xkobold/pi-mcp
+```
+
+### Extension configuration
+
+- **pi-otel**: After installing, configure OTLP settings
+  in `~/.pi/agent/settings.json`:
+  ```json
+  {"otel": {"enabled": true, "protocol": "http/json"}}
+  ```
+  The daemon injects `OTEL_EXPORTER_OTLP_ENDPOINT` at
+  spawn time, which pi-otel respects.
+- **pi-vertex**: After installing, run `/login` inside
+  a Pi session and select "Google Vertex AI". Uses
+  `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and
+  gcloud ADC credentials (mounted via `~/.config/gcloud`).
+- **pi-mcp**: Reads server configs from
+  `~/.pi/agent/mcp.json`. Can import configs from
+  Claude Code, Cursor, and VS Code.
 
 ### Replacing an extension
 
 These are community-maintained packages. If a better
-alternative emerges or one becomes unmaintained, replace
-it in `agent/Containerfile.template` (the `pi install`
-line) and update this documentation. The profile YAML
-itself doesn't reference extensions — they're installed
-at container build time and configured via settings
-files in the mounted `~/.pi` directory.
-
-### Extension configuration
-
-- **pi-otel**: Pre-configured in the seeded
-  `settings.json` for HTTP/JSON protocol. The daemon
-  injects `OTEL_EXPORTER_OTLP_ENDPOINT` at spawn time.
-- **pi-vertex**: Uses `GOOGLE_CLOUD_PROJECT`,
-  `GOOGLE_CLOUD_LOCATION`, and gcloud ADC credentials
-  (mounted via `~/.config/gcloud`). Launch with
-  `pi --provider vertex --model claude-sonnet-4-6`.
-- **pi-mcp**: Reads server configs from
-  `~/.pi/agent/mcp.json`. Can import configs from
-  Claude Code, Cursor, and VS Code.
+alternative emerges or one becomes unmaintained, swap
+it with `pi uninstall <old>` and `pi install <new>`.
+Update this documentation when replacing a recommended
+extension.
 
 ## Known Limitations
 

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -503,27 +503,33 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp
 
 Pi supports Claude and Gemini models via Google Cloud
 Vertex AI through the `@ssweens/pi-vertex` extension.
-Install it inside a Pi session:
+
+**1. Install the extension** inside a Pi session:
 
 ```
 pi install npm:@ssweens/pi-vertex
 ```
 
-Vertex AI requires `--provider vertex` at launch time.
-Edit `agent/profiles/pi.yaml` to add the flag:
+**2. Set the default provider** in
+`~/.pi/agent/settings.json`:
 
-```yaml
-commands:
-  new: ["pi", "--provider", "vertex"]
-  resume: ["bash", "-c",
-    "pi --provider vertex --continue || pi --provider vertex"]
+```json
+{
+  "defaultProvider": "vertex",
+  "defaultModel": "claude-sonnet-4-6"
+}
 ```
 
-You also need the following in your daemon quadlet or
-`podman run` command:
+This avoids needing `--provider vertex` on the command
+line — Pi will use Vertex AI by default for all
+sessions. You can also set `defaultModel` to your
+preferred model.
+
+**3. Add Vertex env vars** to your daemon quadlet or
+`podman run` command. Pi-vertex uses different env var
+names than Claude Code:
 
 ```ini
-# Pi-vertex uses different env var names than Claude Code.
 # If you already have ANTHROPIC_VERTEX_PROJECT_ID and
 # CLOUD_ML_REGION for Claude Code, add these with the
 # same values:

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -26,6 +26,8 @@ podman run -d --name host-daemon --network=host \
   -v $HOME/.gitconfig:/root/.gitconfig:ro \
   -v $HOME/.gemini/:/root/.gemini \
   -v $HOME/.claude/:/root/.claude \
+  -v $HOME/.claude.json:/root/.claude.json:ro \
+  -v $HOME/.pi:/root/.pi \
   -v $HOME/.config/gcloud:/root/.config/gcloud:ro \
   -v $HOME/.config/gh:/root/.config/gh:ro \
   -v $HOME/.config/glab-cli:/root/.config/glab-cli:ro \
@@ -39,11 +41,10 @@ podman run -d --name host-daemon --network=host \
 > label confinement.
 
 > [!TIP]
-> **Missing config directories:** Volume mounts for
-> `~/.claude/` and `~/.gemini/` will fail if the directories
-> don't exist on the host. If you haven't used one of these
-> tools locally, create them first: `mkdir -p ~/.claude
-> ~/.gemini`
+> **Missing config directories:** Volume mounts will fail
+> if the directories don't exist on the host. If you
+> haven't used these tools locally, create them first:
+> `mkdir -p ~/.claude ~/.gemini ~/.pi/agent`
 
 > [!TIP]
 > **Reconfiguring the daemon:** Environment variables and
@@ -78,9 +79,11 @@ podman run -d --name host-daemon --network=host \
 | `/path/to/your/git` | `/git` | rw | Project source code |
 | `~/.ssh` | `/root/.ssh` | ro | SSH keys for git operations |
 | `~/.gitconfig` | `/root/.gitconfig` | ro | Git configuration |
-| `~/.gemini/` | `/root/.gemini` | rw | Gemini CLI settings |
+| `~/.gemini/` | `/root/.gemini` | rw | Gemini CLI / Antigravity CLI settings |
 | `~/.claude/` | `/root/.claude` | rw | Claude Code settings |
-| `~/.config/gcloud` | `/root/.config/gcloud` | ro | GCP credentials |
+| `~/.claude.json` | `/root/.claude.json` | ro | Claude Code MCP server config |
+| `~/.pi/` | `/root/.pi` | rw | Pi coding agent settings and extensions |
+| `~/.config/gcloud` | `/root/.config/gcloud` | ro | GCP credentials (Vertex AI) |
 | `~/.config/gh` | `/root/.config/gh` | ro | GitHub CLI config |
 | `~/.config/glab-cli` | `/root/.config/glab-cli` | ro | GitLab CLI config |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ disable = [
     "too-many-arguments",
     "too-many-positional-arguments",
     "logging-fstring-interpolation",
+    "fixme",
 ]
 
 [tool.coverage.run]

--- a/tui/app.py
+++ b/tui/app.py
@@ -9,6 +9,8 @@ Usage:
     python -m tui.app [--url URL]
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import subprocess

--- a/tui/screens/spawn.py
+++ b/tui/screens/spawn.py
@@ -5,6 +5,8 @@ The user selects host, tool, project, session mode,
 worktree isolation, and optionally a task description.
 """
 
+from __future__ import annotations
+
 from typing import Dict, List
 
 from textual.app import ComposeResult

--- a/tui/terminal_client.py
+++ b/tui/terminal_client.py
@@ -11,6 +11,8 @@ Can be run standalone or invoked by the dashboard TUI
 when attaching to an agent via tmux.
 """
 
+from __future__ import annotations
+
 import argparse
 import asyncio
 import os


### PR DESCRIPTION
## Summary

Adds Pi as a bundled agent profile alongside Claude, Gemini, and Bash. Pi is a popular open-source, provider-agnostic terminal coding agent that supports Claude, GPT, Gemini, Grok, and local models (Ollama).

### Profile (`agent/profiles/pi.yaml`)
- **npm**: `@earendil-works/pi-coding-agent`
- **Color**: green
- **Resume**: `pi --continue` with fallback (enables resume toggle)
- **Auth**: No gate — provider-agnostic, handles own auth
- **Permissions**: None by design ("no popups" philosophy)

### Telemetry (requires pi-otel extension)

Pi uses the community [pi-otel](https://www.npmjs.com/package/pi-otel) extension for OTLP telemetry. It is **not** bundled in the container image — extensions are installed per-user via `pi install npm:pi-otel` and persist in the `~/.pi` host volume mount.

The profile injects three critical env vars at spawn time:
- `OTEL_SERVICE_NAME="{agent_id}"` — required because pi-otel reads this with higher priority than `OTEL_RESOURCE_ATTRIBUTES` (defaults to `"pi"`, breaking multi-instance tracking)
- `PI_OTEL_METRICS="1"` — required because pi-otel disables metrics by default; without it, token/activity/duration histograms are never emitted
- `OTEL_EXPORTER_OTLP_PROTOCOL="http/json"` — matches the daemon's HTTP/JSON receiver

Metric names from pi-otel v0.1.0:
- `gen_ai.client.token.usage` (histogram)
- `gen_ai.client.tool.calls` (counter)
- `gen_ai.client.operation.duration` (histogram, seconds)

### Provisioning
- Wide `passthrough_env` covering core providers (Anthropic, OpenAI, Gemini), Google Cloud/Vertex AI, and optional providers (xAI/Grok, Groq, DeepSeek, Azure OpenAI, Amazon Bedrock)
- Host mount: `~/.pi` → `/root/.pi`

### Known issue: pi-otel HTTP exporter paths
pi-otel v0.1.0 sends HTTP OTLP to `POST /` instead of `/v1/{signal}` ([NikiforovAll/pi-otel#4](https://github.com/NikiforovAll/pi-otel/issues/4)). The daemon has a root-path workaround. An [upstream fix](https://github.com/NikiforovAll/pi-otel/pull/6) has been submitted. TODO comments track removal of the workaround once released.

### Documentation
- Bundled profiles table updated in `docs/agent-profiles.md`
- "Recommended Pi Extensions" section with install commands, configuration, and Vertex AI setup
- Notes on `OTEL_SERVICE_NAME` vs `OTEL_RESOURCE_ATTRIBUTES` precedence for profile authors

### Tests (70 total, 8 new)
- 4 tests for `_resolve_agent_id` Pi fallback paths
- 3 tests for Pi profile configuration (env vars, passthrough_env, telemetry lookup tables)
- 1 test for Pi profile fields

Closes #51