### PR TITLE
Support local profile overrides via *.local.yaml

### DIFF
--- a/agent/profiles.py
+++ b/agent/profiles.py
@@ -254,6 +254,167 @@ def _parse_profile(data: dict) -> AgentProfile:
     return profile
 
 
+# Keys whose values are dicts that should be merged
+# (local overrides base keys, base keys preserved).
+_DICT_MERGE_KEYS = {"env"}
+
+# Keys whose values are lists that should be extended
+# (local items appended, duplicates removed).
+_LIST_EXTEND_KEYS = {"permission_patterns"}
+
+# Nested paths for dict-merge and list-extend behavior
+# inside sub-objects. Each tuple is
+# (parent_key, child_key, merge_type).
+_NESTED_MERGE = [
+    ("commands", None, "dict"),
+    ("auth", None, "dict"),
+    ("telemetry", "token_metrics", "list"),
+    ("telemetry", "activity_metrics", "list"),
+    ("telemetry", "excluded_metrics", "list"),
+    ("mcp", "user_files", "list"),
+    ("sidecar", "fields", "dict"),
+    ("provisioning", "passthrough_env", "list"),
+]
+
+
+def _merge_profile_data(base: dict, override: dict) -> dict:
+    """Deep-merges a local override dict into a base
+    profile dict.
+
+    Merge semantics by field type:
+    - Top-level dicts (env): local keys override base
+      keys; base-only keys are preserved.
+    - Top-level lists (permission_patterns): local items
+      are appended; duplicates removed.
+    - Nested dicts (commands, auth, sidecar.fields):
+      same dict-merge as top-level.
+    - Nested lists (telemetry.token_metrics,
+      mcp.user_files, provisioning.passthrough_env):
+      same list-extend as top-level.
+    - Scalars (binary, color, display_name, etc.):
+      local value replaces base.
+    - The 'name' field is never overridden — it is used
+      for matching only.
+
+    Args:
+        base: The base profile dict from the tracked
+            YAML file.
+        override: The local override dict from the
+            .local.yaml companion file.
+
+    Returns:
+        A new merged dict. Neither input is modified.
+    """
+    # Collect parent keys from _NESTED_MERGE so we
+    # know which top-level keys need dict-merge at the
+    # parent level (not scalar replacement).
+    _nested_parents = {nm[0] for nm in _NESTED_MERGE}
+
+    merged = dict(base)
+
+    for key, value in override.items():
+        # Never override the profile name — it's used
+        # for matching the local file to its base.
+        if key == "name":
+            continue
+
+        if key in _DICT_MERGE_KEYS and isinstance(value, dict):
+            base_dict = merged.get(key, {})
+            if isinstance(base_dict, dict):
+                merged[key] = {**base_dict, **value}
+            else:
+                merged[key] = value
+        elif key in _LIST_EXTEND_KEYS and isinstance(value, list):
+            base_list = merged.get(key, [])
+            if isinstance(base_list, list):
+                combined = list(base_list)
+                for item in value:
+                    if item not in combined:
+                        combined.append(item)
+                merged[key] = combined
+            else:
+                merged[key] = value
+        elif key in _nested_parents and isinstance(value, dict):
+            # Sub-objects with nested merge rules get
+            # dict-merged at the parent level first so
+            # base-only keys (like mcp.project_file)
+            # are preserved. Child-level merge rules
+            # are applied below.
+            base_obj = merged.get(key)
+            if isinstance(base_obj, dict):
+                merged[key] = {**base_obj, **value}
+            else:
+                merged[key] = value
+        else:
+            merged[key] = value
+
+    # Apply child-level merge rules within sub-objects
+    # that exist in both base and override.
+    for parent, child, merge_type in _NESTED_MERGE:
+        if parent not in override or child is None:
+            continue
+        override_parent = override[parent]
+        if not isinstance(override_parent, dict):
+            continue
+        if child not in override_parent:
+            continue
+        base_parent = base.get(parent)
+        if not isinstance(base_parent, dict):
+            continue
+
+        # Work on the already-merged parent dict.
+        merged_parent = dict(merged.get(parent, {}))
+
+        if merge_type == "list":
+            base_list = base_parent.get(child, [])
+            override_list = override_parent.get(child, [])
+            if isinstance(base_list, list) and isinstance(override_list, list):
+                combined = list(base_list)
+                for item in override_list:
+                    if item not in combined:
+                        combined.append(item)
+                merged_parent[child] = combined
+        elif merge_type == "dict":
+            base_dict = base_parent.get(child, {})
+            override_dict = override_parent.get(child, {})
+            if isinstance(base_dict, dict) and isinstance(override_dict, dict):
+                merged_parent[child] = {
+                    **base_dict,
+                    **override_dict,
+                }
+
+        merged[parent] = merged_parent
+
+    return merged
+
+
+def _find_local_override(directory: str, base_name: str) -> Optional[str]:
+    """Finds a .local.yaml/.local.yml/.local.json
+    companion file for a base profile.
+
+    Args:
+        directory: Path to the profiles directory.
+        base_name: Base filename without extension
+            (e.g. 'pi' from 'pi.yaml').
+
+    Returns:
+        Full path to the local override file, or None.
+    """
+    for ext in (".local.yaml", ".local.yml", ".local.json"):
+        path = os.path.join(directory, base_name + ext)
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def _is_local_override(filename: str) -> bool:
+    """Returns True if the filename is a .local override
+    file (e.g. 'pi.local.yaml'). These are processed
+    separately after their base profile is loaded.
+    """
+    return ".local." in filename
+
+
 def load_profiles(
     directory: str = None,
 ) -> Dict[str, AgentProfile]:
@@ -261,7 +422,13 @@ def load_profiles(
 
     Reads all .yaml, .yml, and .json files from the
     specified directory and parses them into AgentProfile
-    instances.
+    instances. After loading each base profile, checks
+    for a companion .local.yaml/.local.yml/.local.json
+    file and deep-merges it into the profile.
+
+    Local override files (*.local.yaml) are gitignored
+    and allow environment-specific customizations
+    without modifying tracked profile files.
 
     Args:
         directory: Path to the profiles directory.
@@ -282,6 +449,10 @@ def load_profiles(
     for filename in sorted(os.listdir(directory)):
         if not filename.endswith((".yaml", ".yml", ".json")):
             continue
+        # Skip .local override files — they are merged
+        # into their base profile below.
+        if _is_local_override(filename):
+            continue
         filepath = os.path.join(directory, filename)
         try:
             with open(filepath, "r", encoding="utf-8") as f:
@@ -289,6 +460,24 @@ def load_profiles(
             if not data or not isinstance(data, dict):
                 print(f"Skipping empty profile: {filename}")
                 continue
+
+            # Check for a .local companion file and
+            # merge it into the base profile data
+            # before parsing.
+            base_name = filename.rsplit(".", 1)[0]
+            local_path = _find_local_override(directory, base_name)
+            if local_path:
+                try:
+                    with open(local_path, "r", encoding="utf-8") as lf:
+                        local_data = yaml.safe_load(lf)
+                    if local_data and isinstance(local_data, dict):
+                        data = _merge_profile_data(data, local_data)
+                        local_name = os.path.basename(local_path)
+                        print(f"Merged local overrides: " f"{local_name}")
+                except Exception as e:
+                    local_name = os.path.basename(local_path)
+                    print(f"Error loading local override " f"{local_name}: {e}")
+
             profile = _parse_profile(data)
             if not profile.name:
                 print(f"Profile missing 'name' field: " f"{filename}")

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -16,6 +16,7 @@ import subprocess
 from unittest.mock import patch, mock_open
 
 import pytest
+import yaml
 
 from agent.host_daemon import HostDaemon, _split_utf8
 
@@ -578,7 +579,310 @@ class TestAgentProfiles:
         assert profiles == {}
 
 
-# ── H. Multi-Root Projects ─────────────────────────────
+# ── H. Local Profile Overrides ─────────────────────
+
+
+class TestLocalProfileOverrides:
+    """Tests for *.local.yaml profile override merging."""
+
+    def test_env_dict_merge(self):
+        """Local env keys override base; base keys preserved."""
+        from agent.profiles import _merge_profile_data
+
+        base = {
+            "name": "test",
+            "env": {"A": "1", "B": "2"},
+        }
+        override = {"name": "test", "env": {"B": "99", "C": "3"}}
+        merged = _merge_profile_data(base, override)
+        assert merged["env"] == {"A": "1", "B": "99", "C": "3"}
+
+    def test_permission_patterns_extend(self):
+        """Local permission_patterns appended, no dupes."""
+        from agent.profiles import _merge_profile_data
+
+        base = {
+            "name": "test",
+            "permission_patterns": ["pat1", "pat2"],
+        }
+        override = {
+            "name": "test",
+            "permission_patterns": ["pat2", "pat3"],
+        }
+        merged = _merge_profile_data(base, override)
+        assert merged["permission_patterns"] == [
+            "pat1",
+            "pat2",
+            "pat3",
+        ]
+
+    def test_scalar_override(self):
+        """Local scalar values replace base values."""
+        from agent.profiles import _merge_profile_data
+
+        base = {
+            "name": "test",
+            "color": "blue",
+            "binary": "old-bin",
+        }
+        override = {"name": "test", "color": "green"}
+        merged = _merge_profile_data(base, override)
+        assert merged["color"] == "green"
+        assert merged["binary"] == "old-bin"
+
+    def test_name_never_overridden(self):
+        """The name field is never overridden by local."""
+        from agent.profiles import _merge_profile_data
+
+        base = {"name": "original"}
+        override = {"name": "sneaky"}
+        merged = _merge_profile_data(base, override)
+        assert merged["name"] == "original"
+
+    def test_commands_dict_merge(self):
+        """Local commands merge per-key into base."""
+        from agent.profiles import _merge_profile_data
+
+        base = {
+            "name": "test",
+            "commands": {
+                "new": ["tool"],
+                "resume": ["tool", "--resume"],
+            },
+        }
+        override = {
+            "name": "test",
+            "commands": {"new": ["tool", "--model", "big"]},
+        }
+        merged = _merge_profile_data(base, override)
+        assert merged["commands"]["new"] == [
+            "tool",
+            "--model",
+            "big",
+        ]
+        assert merged["commands"]["resume"] == [
+            "tool",
+            "--resume",
+        ]
+
+    def test_telemetry_list_extend(self):
+        """Local telemetry lists extend base lists."""
+        from agent.profiles import _merge_profile_data
+
+        base = {
+            "name": "test",
+            "telemetry": {
+                "token_metrics": ["metric.a"],
+                "activity_metrics": ["act.a"],
+            },
+        }
+        override = {
+            "name": "test",
+            "telemetry": {
+                "token_metrics": ["metric.b"],
+                "cost_metric": "cost.new",
+            },
+        }
+        merged = _merge_profile_data(base, override)
+        assert merged["telemetry"]["token_metrics"] == [
+            "metric.a",
+            "metric.b",
+        ]
+        # Scalar within telemetry is overridden
+        assert merged["telemetry"]["cost_metric"] == "cost.new"
+        # Untouched base list preserved
+        assert merged["telemetry"]["activity_metrics"] == [
+            "act.a",
+        ]
+
+    def test_provisioning_passthrough_extend(self):
+        """Local passthrough_env extends base list."""
+        from agent.profiles import _merge_profile_data
+
+        base = {
+            "name": "test",
+            "provisioning": {
+                "passthrough_env": ["KEY_A", "KEY_B"],
+            },
+        }
+        override = {
+            "name": "test",
+            "provisioning": {
+                "passthrough_env": ["KEY_B", "KEY_C"],
+            },
+        }
+        merged = _merge_profile_data(base, override)
+        assert merged["provisioning"]["passthrough_env"] == [
+            "KEY_A",
+            "KEY_B",
+            "KEY_C",
+        ]
+
+    def test_mcp_user_files_extend(self):
+        """Local mcp.user_files extends base list."""
+        from agent.profiles import _merge_profile_data
+
+        base = {
+            "name": "test",
+            "mcp": {
+                "project_file": ".mcp.json",
+                "user_files": ["~/.tool/config.json"],
+            },
+        }
+        override = {
+            "name": "test",
+            "mcp": {"user_files": ["~/.tool/extra.json"]},
+        }
+        merged = _merge_profile_data(base, override)
+        assert merged["mcp"]["user_files"] == [
+            "~/.tool/config.json",
+            "~/.tool/extra.json",
+        ]
+        # project_file preserved from base
+        assert merged["mcp"]["project_file"] == ".mcp.json"
+
+    def test_sidecar_fields_dict_merge(self):
+        """Local sidecar.fields merges as a dict."""
+        from agent.profiles import _merge_profile_data
+
+        base = {
+            "name": "test",
+            "sidecar": {
+                "fields": {"activity": "cwd"},
+            },
+        }
+        override = {
+            "name": "test",
+            "sidecar": {
+                "fields": {"exit_code": "rc"},
+            },
+        }
+        merged = _merge_profile_data(base, override)
+        assert merged["sidecar"]["fields"] == {
+            "activity": "cwd",
+            "exit_code": "rc",
+        }
+
+    def test_load_profiles_with_local_override(self):
+        """load_profiles merges .local.yaml into the
+        base profile."""
+        import tempfile
+
+        from agent.profiles import load_profiles
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write base profile
+            base = {
+                "name": "myagent",
+                "display_name": "My Agent",
+                "binary": "myagent",
+                "color": "blue",
+                "env": {"A": "1"},
+                "commands": {"new": ["myagent"]},
+            }
+            with open(
+                os.path.join(tmpdir, "myagent.yaml"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                yaml.dump(base, f)
+
+            # Write local override
+            local = {
+                "name": "myagent",
+                "env": {"B": "2"},
+                "color": "green",
+            }
+            with open(
+                os.path.join(tmpdir, "myagent.local.yaml"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                yaml.dump(local, f)
+
+            profiles = load_profiles(tmpdir)
+
+        p = profiles["myagent"]
+        # env merged
+        assert p.env == {"A": "1", "B": "2"}
+        # scalar overridden
+        assert p.color == "green"
+        # base value preserved
+        assert p.display_name == "My Agent"
+
+    def test_local_override_not_loaded_standalone(self):
+        """A .local.yaml file is not loaded as a
+        standalone profile."""
+        import tempfile
+
+        from agent.profiles import load_profiles
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Only a local file, no base
+            local = {
+                "name": "orphan",
+                "color": "red",
+            }
+            with open(
+                os.path.join(tmpdir, "orphan.local.yaml"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                yaml.dump(local, f)
+
+            profiles = load_profiles(tmpdir)
+
+        assert "orphan" not in profiles
+
+    def test_local_override_error_handled(self):
+        """A malformed .local.yaml doesn't crash profile
+        loading — the base profile loads without it."""
+        import tempfile
+
+        from agent.profiles import load_profiles
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write valid base profile
+            base = {
+                "name": "myagent",
+                "binary": "myagent",
+                "color": "blue",
+            }
+            with open(
+                os.path.join(tmpdir, "myagent.yaml"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                yaml.dump(base, f)
+
+            # Write malformed local override
+            with open(
+                os.path.join(tmpdir, "myagent.local.yaml"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write("{{{invalid yaml")
+
+            profiles = load_profiles(tmpdir)
+
+        # Base profile still loaded
+        assert "myagent" in profiles
+        assert profiles["myagent"].color == "blue"
+
+    def test_base_not_modified(self):
+        """_merge_profile_data does not mutate inputs."""
+        from agent.profiles import _merge_profile_data
+
+        base = {"name": "t", "env": {"A": "1"}}
+        override = {"name": "t", "env": {"B": "2"}}
+        base_copy = {"name": "t", "env": {"A": "1"}}
+        override_copy = {"name": "t", "env": {"B": "2"}}
+        _merge_profile_data(base, override)
+        assert base == base_copy
+        assert override == override_copy
+
+
+# ── I. Multi-Root Projects ─────────────────────────────
 
 
 class TestMultiRoot:

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -177,6 +177,79 @@ provisioning:
     - MY_AGENT_API_KEY
 ```
 
+## Local Overrides
+
+Profile files in `agent/profiles/` are tracked by Git.
+To customize a profile for your environment without
+modifying tracked files, create a companion
+`.local.yaml` file:
+
+```
+agent/profiles/pi.local.yaml
+```
+
+The `.local` suffix is already in `.gitignore`, so
+these files won't be committed or cause dirty working
+trees.
+
+### Example
+
+To allow Pi to connect to MCP servers with self-signed
+TLS certificates:
+
+```yaml
+# agent/profiles/pi.local.yaml
+name: pi
+env:
+  NODE_TLS_REJECT_UNAUTHORIZED: "0"
+```
+
+To add a custom model flag and extra provider key:
+
+```yaml
+# agent/profiles/claude.local.yaml
+name: claude
+commands:
+  new: ["claude", "--model", "opus"]
+  resume: ["bash", "-c", "claude --continue --model opus || claude --model opus"]
+env:
+  MY_CUSTOM_VAR: "value"
+```
+
+### Merge behavior
+
+Local overrides are merged into the base profile
+before parsing. The merge semantics depend on the
+field type:
+
+| Field type | Behavior | Example |
+|-----------|----------|--------|
+| **Scalars** (`binary`, `color`, etc.) | Local replaces base | `color: green` overrides `color: blue` |
+| **`env`** (dict) | Dict merge — local keys override, base keys preserved | Local `{B: 2}` + base `{A: 1}` → `{A: 1, B: 2}` |
+| **`commands`** (dict) | Dict merge — local keys override per-command | Local `{new: [...]}` overrides `new`, preserves `resume` |
+| **`permission_patterns`** (list) | Extend — local items appended, duplicates removed | |
+| **`telemetry.*_metrics`** (lists) | Extend | `token_metrics`, `activity_metrics`, `excluded_metrics` |
+| **`mcp.user_files`** (list) | Extend | |
+| **`provisioning.passthrough_env`** (list) | Extend | |
+| **`sidecar.fields`** (dict) | Dict merge | |
+| **`name`** | Never overridden | Used for matching only |
+
+### Supported file extensions
+
+The daemon checks for companions in this order:
+1. `{name}.local.yaml`
+2. `{name}.local.yml`
+3. `{name}.local.json`
+
+Only the first match is used.
+
+### Error handling
+
+If a `.local` file is malformed (invalid YAML/JSON),
+the base profile loads without the override and the
+error is logged. A `.local` file without a matching
+base profile is silently ignored.
+
 ## How Profiles Are Used
 
 | Feature | Profile Field | Used By |


### PR DESCRIPTION
## Summary

Agent profiles in `agent/profiles/` are tracked by Git. Users who need environment-specific customizations (e.g., `NODE_TLS_REJECT_UNAUTHORIZED=0` for self-signed certs, extra provider API keys, custom model flags) must modify tracked files, creating dirty working trees and risking accidental commits.

This adds support for `*.local.yaml` companion files that are deep-merged into the base profile at load time. The `.gitignore` already covers `*.local`.

### Example

```yaml
# agent/profiles/pi.local.yaml
name: pi
env:
  NODE_TLS_REJECT_UNAUTHORIZED: "0"
```

### Merge semantics

| Field type | Behavior |
|-----------|----------|
| Scalars (`binary`, `color`, etc.) | Local replaces base |
| `env` (dict) | Dict merge — local keys override, base keys preserved |
| `commands` (dict) | Dict merge per-command (`new`, `resume`) |
| `permission_patterns` (list) | Extend — append, deduplicate |
| `telemetry.*_metrics` (lists) | Extend |
| `mcp.user_files` (list) | Extend |
| `provisioning.passthrough_env` (list) | Extend |
| `sidecar.fields` (dict) | Dict merge |
| `name` | Never overridden (matching only) |

### Changes

- **`agent/profiles.py`**: `_merge_profile_data()` for deep-merge, `_find_local_override()` for companion discovery, `_is_local_override()` to skip `.local` files in the main loop, updated `load_profiles()` to merge companions before parsing
- **`agent/tests/test_host_daemon.py`**: 14 new tests covering all merge types, integration with `load_profiles`, orphan/malformed local files, and input immutability
- **`docs/agent-profiles.md`**: New "Local Overrides" section with examples, merge table, supported extensions, and error handling

### Error handling

- Malformed `.local` files are logged and skipped — base profile loads without override
- Orphan `.local` files (no matching base) are silently ignored
- `.local` files checked in order: `.local.yaml`, `.local.yml`, `.local.json` (first match wins)

Closes #85