### PR TITLE
fix: replay terminal history when daemon joins after UI client

### DIFF
--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -127,6 +127,39 @@ async def handle_join_room(sid, data):
                 {"agent_id": agent_id},
                 namespace="/terminal",
             )
+        else:
+            # A daemon just joined an agent room.  If a UI
+            # client is already in the room (e.g. a browser
+            # tab that refreshed while the daemon was
+            # restarting), re-request history so the
+            # terminal gets populated.  Without this, the
+            # UI's initial request_history fires before the
+            # daemon is ready, history never arrives, and
+            # the frontend declares the session lost.
+            room_sids = sio.manager.get_participants(
+                namespace="/terminal", room=agent_id
+            )
+            for room_sid, _ in room_sids:
+                if room_sid == sid:
+                    continue
+                room_session = await sio.get_session(room_sid, namespace="/terminal")
+                is_room_host = (
+                    room_session.get("is_host", False) if room_session else False
+                )
+                if not is_room_host:
+                    # At least one UI client is waiting —
+                    # request history replay from the daemon.
+                    print(
+                        f"Re-requesting history for "
+                        f"{agent_id} (daemon joined "
+                        f"after UI client)"
+                    )
+                    await sio.emit(
+                        "request_history",
+                        {"agent_id": agent_id},
+                        namespace="/terminal",
+                    )
+                    break
 
 
 @sio.on("request_projects", namespace="/terminal")

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -391,14 +391,19 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
       performFit();
 
       // Detect stale sessions: if history never completes
-      // within 5s, the daemon likely no longer has this agent
+      // within 15s, the daemon likely no longer has this
+      // agent.  The timeout must be long enough to cover
+      // daemon restarts — the backend re-requests history
+      // when a daemon joins a room that already has a UI
+      // client, but the daemon needs time to reconnect,
+      // spawn the agent, and join the room first.
       if (historyTimeoutRef.current) clearTimeout(historyTimeoutRef.current);
       historyTimeoutRef.current = setTimeout(() => {
         if (isReplaying.current) {
           setSessionLost(true);
           isReplaying.current = false;
         }
-      }, 5000);
+      }, 15000);
     });
 
     socket.on('history_complete', (data: { agent_id: string }) => {


### PR DESCRIPTION
## Problem

When a browser tab is open during a daemon restart, the UI's initial `request_history` fires before the daemon has reconnected and joined the agent's room. The request goes nowhere, no `history_complete` arrives, and after 5 seconds the frontend declares the session lost and spawns a replacement agent — losing all terminal history.

## Root Cause

The backend emits `request_history` when a UI client joins a room, but if the daemon hasn't joined that room yet (still restarting), the request is silently dropped. The frontend's 5-second stale session timeout then triggers auto-reconnect, which stops the old agent and spawns a new one with an empty history deque.

## Fix

1. **Backend (`socket.py`)**: When a host daemon joins a room that already has a UI client waiting, re-emit `request_history` so the daemon replays its deque to the waiting terminal.
2. **Frontend (`Terminal.tsx`)**: Increase the stale session timeout from 5s to 15s to give the daemon time to restart, spawn agents, and rejoin rooms before the UI gives up.

## Relationship to #87

This is a **partial fix** for #87. It addresses the daemon-restart scenario (UI connected before daemon is ready) but does not fix the close/reopen popup race condition where `enter_room` hasn't fully registered the UI client before history chunks arrive via `room=agent_id`. A complete fix for #87 would require emitting history directly to the UI client's `sid` instead of the room.

## Testing

- Open a terminal window for an agent session
- Restart the daemon container
- Refresh the browser tab
- Verify terminal history is replayed instead of showing an empty terminal

Co-authored-by: Claude claude@anthropic.com