### PR TITLE
docs: add restart policy to all systemd Quadlet templates

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -102,7 +102,7 @@ recovers automatically from unexpected exits:
 ```ini
 [Service]
 Restart=on-failure
-RestartSec=5
+RestartSec=5s
 ```
 
 ## Telemetry

--- a/docs/systemd-quadlets.md
+++ b/docs/systemd-quadlets.md
@@ -32,6 +32,12 @@ Volume=agent-dashboard-data.volume:/app/data
 Environment=DATABASE_URL=sqlite:////app/data/agent_dashboard.db
 Environment=BYPASS_AUTH=true
 
+[Service]
+# Restart on failure, e.g. if the database or network
+# is not fully ready at boot.
+Restart=on-failure
+RestartSec=5s
+
 [Install]
 WantedBy=multi-user.target
 ```
@@ -45,6 +51,12 @@ After=network-online.target agent-dashboard-backend.service
 [Container]
 Image=localhost/agent-dashboard_frontend:latest
 PublishPort=8080:80
+
+[Service]
+# Restart on failure, e.g. if the backend is not yet
+# accepting connections at boot.
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target
@@ -96,6 +108,12 @@ Volume=%h/.claude/:/root/.claude
 Volume=%h/.config/gcloud:/root/.config/gcloud:ro
 Volume=%h/.config/gh:/root/.config/gh:ro
 Volume=%h/.config/glab-cli:/root/.config/glab-cli:ro
+
+[Service]
+# Restart on failure, e.g. if the dashboard host or
+# network is not fully ready at boot.
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Problem

During boot, systemd services can fail if they attempt to connect to external endpoints or local dependencies (database, Socket.IO dashboard, network) before those are fully active. Without a restart policy, services fail once and remain stopped until manually restarted.

## Fix

Add a `[Service]` section with `Restart=on-failure` and `RestartSec=5s` to all three Quadlet container templates in `docs/systemd-quadlets.md`:

- `agent-dashboard-backend.container`
- `agent-dashboard-frontend.container`
- `agent-dashboard-daemon.container`

Also update `agent/README.md` to use `RestartSec=5s` (with explicit `s` suffix) for consistency with standard systemd duration syntax.

Co-authored-by: Claude claude@anthropic.com