### PR TITLE
Revert: replay terminal history when daemon joins after UI client (#88)

### DIFF
--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -127,39 +127,6 @@ async def handle_join_room(sid, data):
                 {"agent_id": agent_id},
                 namespace="/terminal",
             )
-        else:
-            # A daemon just joined an agent room.  If a UI
-            # client is already in the room (e.g. a browser
-            # tab that refreshed while the daemon was
-            # restarting), re-request history so the
-            # terminal gets populated.  Without this, the
-            # UI's initial request_history fires before the
-            # daemon is ready, history never arrives, and
-            # the frontend declares the session lost.
-            room_sids = sio.manager.get_participants(
-                namespace="/terminal", room=agent_id
-            )
-            for room_sid, _ in room_sids:
-                if room_sid == sid:
-                    continue
-                room_session = await sio.get_session(room_sid, namespace="/terminal")
-                is_room_host = (
-                    room_session.get("is_host", False) if room_session else False
-                )
-                if not is_room_host:
-                    # At least one UI client is waiting —
-                    # request history replay from the daemon.
-                    print(
-                        f"Re-requesting history for "
-                        f"{agent_id} (daemon joined "
-                        f"after UI client)"
-                    )
-                    await sio.emit(
-                        "request_history",
-                        {"agent_id": agent_id},
-                        namespace="/terminal",
-                    )
-                    break
 
 
 @sio.on("request_projects", namespace="/terminal")

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -393,19 +393,14 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
       performFit();
 
       // Detect stale sessions: if history never completes
-      // within 15s, the daemon likely no longer has this
-      // agent.  The timeout must be long enough to cover
-      // daemon restarts — the backend re-requests history
-      // when a daemon joins a room that already has a UI
-      // client, but the daemon needs time to reconnect,
-      // spawn the agent, and join the room first.
+      // within 5s, the daemon likely no longer has this agent
       if (historyTimeoutRef.current) clearTimeout(historyTimeoutRef.current);
       historyTimeoutRef.current = setTimeout(() => {
         if (isReplaying.current) {
           setSessionLost(true);
           isReplaying.current = false;
         }
-      }, 15000);
+      }, 5000);
     });
 
     socket.on('history_complete', (data: { agent_id: string }) => {


### PR DESCRIPTION
## Summary

Reverts PR #88 (`b8e5c1d`) which introduced daemon instability when Pi agent sessions fail (e.g., during a rebase). The bug causes the daemon to become unresponsive, requiring container restarts and preventing new agent sessions from spawning.

## Context

The original fix added `request_history` emission on daemon room joins to handle the case where a UI client connects before the daemon. The implementation caused issues with agent session lifecycle management under failure conditions.

Issue #87 is reopened for a revised approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)