### PR TITLE
feat: wrap agent processes in tmux sessions (Phase 1 of #83)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ agent/Containerfile
 
 # Local Agent Configs
 .claude/settings.local.json
+.coverage

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,6 +1,6 @@
 # Agent Dashboard Host Daemon
 
-The Host Daemon runs on remote development machines and manages AI agent sessions for the Agent Dashboard. It listens for spawn commands from the Hub, multiplexes agent I/O through pseudo-terminals, and relays output to the frontend via Socket.IO.
+The Host Daemon runs on remote development machines and manages AI agent sessions for the Agent Dashboard. It listens for spawn commands from the Hub, spawns agents inside tmux sessions for terminal stability, and relays I/O to the frontend via Socket.IO.
 
 ## Prerequisites
 - Python 3.9+

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -209,12 +209,33 @@ class HostDaemon:
             cols = data.get("cols")
             rows = data.get("rows")
             if agent_id in self.agents and cols and rows:
+                # Resize the tmux window so the agent TUI
+                # redraws at the new dimensions.  Also
+                # resize the outer PTY so the kernel's
+                # line discipline matches.
                 master_fd = self.agents[agent_id]["master_fd"]
                 size = struct.pack("HHHH", rows, cols, 0, 0)
                 try:
                     fcntl.ioctl(master_fd, termios.TIOCSWINSZ, size)
                 except Exception as e:
-                    log.info(f"Failed to resize terminal {agent_id}: {e}")
+                    log.info(f"Failed to resize PTY {agent_id}: {e}")
+                try:
+                    subprocess.run(
+                        [
+                            "tmux",
+                            "resize-window",
+                            "-t",
+                            agent_id,
+                            "-x",
+                            str(cols),
+                            "-y",
+                            str(rows),
+                        ],
+                        capture_output=True,
+                        check=False,
+                    )
+                except Exception as e:
+                    log.info(f"Failed to resize tmux window" f" {agent_id}: {e}")
 
         @self.sio.on("spawn_agent", namespace="/terminal")
         async def on_spawn_agent(data):
@@ -848,16 +869,50 @@ class HostDaemon:
                     f"{profile.sidecar.prompt_command} > {sidecar_path}"
                 )
 
+            # Wrap the agent command in a tmux session.
+            # tmux manages the terminal buffer, handles
+            # SIGWINCH natively, and persists across daemon
+            # restarts (Phase 3).  The session name is the
+            # agent_id so we can target it for resize and
+            # cleanup.  remain-on-exit keeps the tmux
+            # session alive after the agent process exits
+            # so the daemon's PTY read loop sees EOF and
+            # triggers close_agent cleanly.
+            #
+            # Environment variables are exported before
+            # exec because tmux new-session does not
+            # forward the child's env to the spawned
+            # command — it inherits from the tmux server.
+            # We use env(1) to inject them explicitly.
+            tmux_session = agent_id
+            tmux_cmd = [
+                "tmux",
+                "new-session",
+                "-d",
+                "-s",
+                tmux_session,
+                "-x",
+                str(cols),
+                "-y",
+                str(rows),
+                "env",
+            ]
+            # Pass all env vars through env(1) so the
+            # agent process inherits them inside tmux.
+            for k, v in env.items():
+                tmux_cmd.append(f"{k}={v}")
+            tmux_cmd.extend(cmd)
+
             try:
-                os.execvpe(cmd[0], cmd, env)
+                os.execvpe(tmux_cmd[0], tmux_cmd, env)
             except Exception as e:
-                log.info(f"Failed to execute {cmd}: {e}")
+                log.info(f"Failed to execute {tmux_cmd}: {e}")
                 os._exit(1)
         else:  # Parent process
-            # Set initial PTY dimensions before the agent
-            # starts producing output. This avoids the brief
-            # period where the PTY defaults to 80x24 while the
-            # frontend sends a resize after connecting.
+            # Set initial PTY dimensions.  The tmux
+            # new-session -x/-y flags set the window size,
+            # but we also set the outer PTY so the first
+            # output frame renders at the correct size.
             try:
                 size = struct.pack("HHHH", rows, cols, 0, 0)
                 fcntl.ioctl(fd, termios.TIOCSWINSZ, size)
@@ -992,13 +1047,24 @@ class HostDaemon:
             await asyncio.sleep(0.01)
 
     def close_agent(self, agent_id: str):
-        """Closes the PTY fd and removes an agent from tracking."""
+        """Closes the PTY fd, kills the tmux session, and
+        removes an agent from tracking."""
         if agent_id in self.agents:
             log.info(f"Closing agent {agent_id}")
             fd = self.agents[agent_id]["master_fd"]
             try:
                 os.close(fd)
             except OSError:
+                pass
+            # Kill the tmux session to clean up the
+            # server-side window and processes.
+            try:
+                subprocess.run(
+                    ["tmux", "kill-session", "-t", agent_id],
+                    capture_output=True,
+                    check=False,
+                )
+            except Exception:
                 pass
             # Clean up sidecar telemetry file if the
             # profile defines one

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -874,10 +874,13 @@ class HostDaemon:
             # SIGWINCH natively, and persists across daemon
             # restarts (Phase 3).  The session name is the
             # agent_id so we can target it for resize and
-            # cleanup.  remain-on-exit keeps the tmux
-            # session alive after the agent process exits
-            # so the daemon's PTY read loop sees EOF and
-            # triggers close_agent cleanly.
+            # cleanup.
+            #
+            # The tmux client must run ATTACHED (no -d
+            # flag).  With -d, tmux forks a server and
+            # the client exits immediately — the PTY
+            # closes, the daemon sees EOF, and the agent
+            # enters a crash/respawn loop.
             #
             # Environment variables are exported before
             # exec because tmux new-session does not
@@ -888,7 +891,6 @@ class HostDaemon:
             tmux_cmd = [
                 "tmux",
                 "new-session",
-                "-d",
                 "-s",
                 tmux_session,
                 "-x",

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -2,8 +2,8 @@
 
 The host daemon runs on each development machine as a
 containerized service. It connects to the hub, spawns AI agent
-sessions in pseudo-terminals, relays I/O, and collects
-OpenTelemetry telemetry.
+sessions in pseudo-terminals (via tmux), relays I/O, and
+collects OpenTelemetry telemetry.
 
 For basic setup, see the [Getting Started](../README.md#4-deploy-the-host-daemon)
 section of the main README.
@@ -176,6 +176,31 @@ services:
 > automatically. The version is displayed in the dashboard
 > header and used for upgrade notifications.
 
+## Agent Process Architecture
+
+Each agent runs inside a **tmux session** rather than
+directly in a PTY. The daemon forks a child process that
+executes `tmux new-session -s {agent_id}`, and the agent
+command runs inside the tmux window. The daemon reads
+and writes the tmux session's outer PTY, so the I/O
+relay is transparent.
+
+Benefits:
+- **Resize stability** — tmux handles `SIGWINCH`
+  natively, reducing resize race conditions.
+- **Terminal query isolation** — tmux answers DA/CPR
+  escape sequence queries locally instead of routing
+  them through the Socket.IO path.
+- **Foundation for persistence** — future phases will
+  use tmux's scrollback buffer for history replay and
+  reattach to surviving tmux sessions after daemon
+  restarts (see [#83](https://github.com/dustinblack/agent-dashboard/issues/83)).
+
+The tmux session name is the agent's UUID, used for
+targeted resize (`tmux resize-window`) and cleanup
+(`tmux kill-session`). tmux is included in the
+container image.
+
 ## Included Tools
 
 The daemon container bundles the following tools:
@@ -187,6 +212,7 @@ The daemon container bundles the following tools:
 | **Google Cloud CLI** (`gcloud`) | GCP authentication for Claude via Vertex AI |
 | **GitHub CLI** (`gh`) | GitHub interaction (PRs, issues, etc.) |
 | **GitLab CLI** (`glab`) | GitLab interaction (MRs, issues, etc.) |
+| **tmux** | Terminal multiplexer for agent session management |
 | **Git** | Version control |
 | **Podman** | Container builds and runtimes (podman-in-podman) |
 | **Go** (`golang`) | Go builds and tests |


### PR DESCRIPTION
## Summary

Run each agent inside a tmux session instead of executing the agent command directly in the PTY. This is Phase 1 of #83 — the foundation for persistent terminal state, resize stability, and daemon restart recovery.

## Changes

### `agent/host_daemon.py`

**`spawn_agent()`**: Wrap the agent command in `tmux new-session -s {agent_id} -x {cols} -y {rows} env KEY=VAL... agent_cmd`. The tmux client runs attached (no `-d` flag) so it holds the PTY open for the daemon's read loop. Environment variables are passed through `env(1)` because tmux inherits from the server, not the forking child.

**`terminal_resize`**: After the `TIOCSWINSZ` ioctl on the outer PTY, also runs `tmux resize-window -t {agent_id} -x {cols} -y {rows}` so the tmux window and the agent inside it see the new dimensions.

**`close_agent()`**: Kills the tmux session (`tmux kill-session -t {agent_id}`) to clean up server-side windows and processes.

### Documentation

- `docs/host-daemon.md`: New "Agent Process Architecture" section, tmux added to tools table
- `agent/README.md`: Updated description to reflect tmux usage

### What's unchanged

- PTY read/write loop (`watch_agents`) — reads tmux's PTY output
- History deque — still in-memory (Phase 2 replaces with `capture-pane`)
- Input routing — writes to the same `master_fd`

## Testing

Validated with Pi, Antigravity, and Claude Code sessions:
- ✅ TUI rendering (colors, cursor movement, interactive prompts)
- ✅ Terminal resize
- ✅ Agent cleanup (no orphan tmux sessions)
- ✅ pi-task sub-agents spawn in visible tmux panes within the session

## Future Phases

- **Phase 2**: Replace in-memory deque with `tmux capture-pane` for history replay
- **Phase 3**: Detect and reattach existing tmux sessions on daemon restart

Closes Phase 1 of #83.

Co-authored-by: Claude claude@anthropic.com