### PR TITLE
fix: reduce terminal jitter on tmux session startup

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -57,6 +57,28 @@ PERMISSION_IDLE_SECONDS = 2
 # output before pattern matching.
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
+# Terminal capability queries that tmux sends on startup.
+# These trigger round-trip responses through Socket.IO →
+# xterm.js → Socket.IO → daemon → PTY, causing visible
+# jitter as tmux redraws after each response.  Stripping
+# them from the output stream prevents the round-trip
+# without affecting tmux functionality (it falls back to
+# defaults for unresponded queries).
+_TMUX_QUERIES = re.compile(
+    rb"\x1b\[c"  # DA1 (Device Attributes)
+    rb"|\x1b\[>c"  # DA2 (Secondary Device Attributes)
+    rb"|\x1b\[>q"  # Terminal name query (XTVERSION)
+    rb"|\x1b\]10;\?\x1b\\"  # Foreground color query
+    rb"|\x1b\]11;\?\x1b\\"  # Background color query
+)
+
+# Seconds to buffer output after agent spawn before
+# relaying to the frontend.  tmux emits several bursts
+# of startup escape sequences over ~300 ms; buffering
+# coalesces them into a single Socket.IO emit, which
+# eliminates visible terminal jitter on connect.
+_STARTUP_BUFFER_SECS = 0.5
+
 
 def _split_utf8(data: bytes) -> tuple:
     """Splits a byte string at the last complete UTF-8 character boundary.
@@ -932,6 +954,8 @@ class HostDaemon:
                 "permission_waiting": False,
                 "permission_candidate": 0,
                 "utf8_buffer": b"",
+                "startup_buffer": b"",
+                "spawn_time": time.monotonic(),
                 "worktree_path": worktree_path,
                 "worktree_branch": worktree_branch,
                 "original_project_dir": original_project_dir,
@@ -1003,6 +1027,25 @@ class HostDaemon:
                         if not chunk:
                             break
                         raw += chunk
+
+                    # Strip tmux terminal capability queries
+                    # to prevent round-trip jitter.
+                    raw = _TMUX_QUERIES.sub(b"", raw)
+                    if not raw:
+                        continue
+
+                    # Buffer output during the startup
+                    # window so tmux's initialization bursts
+                    # are coalesced into one emit.
+                    elapsed = time.monotonic() - info.get("spawn_time", 0)
+                    if elapsed < _STARTUP_BUFFER_SECS:
+                        info["startup_buffer"] += raw
+                        continue
+
+                    # Flush any buffered startup output.
+                    if info.get("startup_buffer"):
+                        raw = info.pop("startup_buffer") + raw
+
                     if self.sio.connected:
                         # Prepend any leftover bytes from a
                         # previously split UTF-8 character.


### PR DESCRIPTION
## Problem

After PR #95 wrapped agents in tmux sessions, terminal connections show visible jitter — the terminal flashes through multiple render frames before settling. This is caused by tmux's startup sequence:

1. tmux sends ~100 escape sequences over ~300ms, including Device Attributes (DA1/DA2), terminal name, and color queries
2. These queries get relayed through Socket.IO to xterm.js, which responds
3. Responses travel back through Socket.IO → daemon → tmux PTY
4. tmux processes responses and redraws — producing another burst of output
5. The cycle repeats for each query type, causing 3-4 visible render frames

## Fix

### 1. Strip tmux terminal capability queries from output

Filter DA1 (`\x1b[c`), DA2 (`\x1b[>c`), XTVERSION (`\x1b[>q`), and foreground/background color queries from the output stream before relaying to the frontend. tmux falls back to defaults for unresponded queries — this is safe and eliminates the round-trip redraw cycle entirely.

### 2. Buffer startup output for 500ms

Coalesce tmux's initialization bursts into a single Socket.IO emit instead of 3-4 separate frames. The buffer is flushed (prepended to the next output chunk) after the 500ms window expires.

## Testing

- Spawn agent sessions and verify the terminal renders cleanly without flashing
- Verify agent TUI (colors, cursor movement, interactive prompts) still works correctly
- Verify terminal resize still works

## Related

- PR #95 — Phase 1 tmux wrapping
- #83 — tmux agent sessions tracking issue