### PR TITLE
fix: remove --privileged from rootless Podman configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ podman build -t agent-dashboard-daemon -f Containerfile .
 Run with minimum required configuration:
 
 ```bash
-podman run -d --name host-daemon --network=host --privileged \
+podman run -d --name host-daemon --network=host \
   -e DASHBOARD_URL="http://your-server-ip:8000" \
   -e HOST_TOKEN="secret-token-123" \
   -e PROJECTS_ROOT="/git" \

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -12,7 +12,6 @@ section of the main README.
 
 ```bash
 podman run -d --name host-daemon --network=host \
-  --privileged \
   -e DASHBOARD_URL="http://your-server-ip:8000" \
   -e HOST_TOKEN="secret-token-123" \
   -e PROJECTS_ROOT="/git" \
@@ -35,10 +34,30 @@ podman run -d --name host-daemon --network=host \
 ```
 
 > [!WARNING]
-> `--privileged` is required for container-in-container support
-> (e.g., agents building and running containers during
-> development sessions). This also implicitly disables SELinux
-> label confinement.
+> **Do not use `--privileged` with rootless Podman.** In
+> rootless mode, `--privileged` causes `crun` to attempt
+> privileged mount operations that the unprivileged user
+> namespace cannot perform, resulting in exit code 126
+> (permission denied). Standard agent operations do not
+> require `--privileged`.
+
+> [!TIP]
+> **Nested containers (podman-in-podman):** If agents need
+> to build or run containers inside the daemon container,
+> mount the host sub-ID mapping files instead of using
+> `--privileged`:
+> ```bash
+> -v /etc/subuid:/etc/subuid:ro \
+> -v /etc/subgid:/etc/subgid:ro
+> ```
+> For Quadlet configurations, add:
+> ```ini
+> Volume=/etc/subuid:/etc/subuid:ro
+> Volume=/etc/subgid:/etc/subgid:ro
+> ```
+> This gives the container access to user namespace
+> sub-ID ranges needed for rootless container image
+> layer unpacking without requiring host root privileges.
 
 > [!TIP]
 > **Missing config directories:** Volume mounts will fail

--- a/docs/systemd-quadlets.md
+++ b/docs/systemd-quadlets.md
@@ -83,7 +83,6 @@ After=network-online.target
 [Container]
 Image=localhost/agent-dashboard-daemon:latest
 Network=host
-PodmanArgs=--privileged
 
 # Environment Variables
 Environment=DASHBOARD_URL=http://your-server-ip:8000
@@ -108,6 +107,13 @@ Volume=%h/.claude/:/root/.claude
 Volume=%h/.config/gcloud:/root/.config/gcloud:ro
 Volume=%h/.config/gh:/root/.config/gh:ro
 Volume=%h/.config/glab-cli:/root/.config/glab-cli:ro
+
+# Nested container support (optional)
+# Uncomment these lines if agents need to run podman-in-podman
+# for container builds. Do NOT use --privileged — it causes
+# exit code 126 in rootless mode.
+#Volume=/etc/subuid:/etc/subuid:ro
+#Volume=/etc/subgid:/etc/subgid:ro
 
 [Service]
 # Restart on failure, e.g. if the dashboard host or


### PR DESCRIPTION
## Problem

After rebuilding the host daemon container, rootless Podman Quadlet services crash-loop with exit code 126:

```
Process: ExecStart=/usr/bin/podman run ... --privileged localhost/agent-dashboard-daemon:latest
  (code=exited, status=126)
```

## Root Cause

`--privileged` in rootless Podman instructs `crun` to unmask `/proc` and mount `/sys` read-write. Because the process runs in an unprivileged user namespace without host root capabilities, the kernel denies these `mount()` syscalls with `EPERM`. `crun` fails setup and exits with code 126.

Standard agent operations (Claude Code, Pi, Antigravity, Gemini, tmux, git, compilers, OTLP servers) do not require `--privileged`.

## Changes

- **`README.md`**: Remove `--privileged` from `podman run` quick-start command
- **`docs/host-daemon.md`**: Remove `--privileged` from full run command; replace the old warning with a callout explaining exit code 126 and documenting the `subuid/subgid` mount alternative for nested Podman
- **`docs/systemd-quadlets.md`**: Remove `PodmanArgs=--privileged` from the daemon Quadlet template

## Nested Container Support

If agents need podman-in-podman for container builds, mount host sub-ID files instead:

```ini
Volume=/etc/subuid:/etc/subuid:ro
Volume=/etc/subgid:/etc/subgid:ro
```

Co-authored-by: Claude claude@anthropic.com