### PR TITLE
fix: add default tmux.conf with mouse scrolling support

### DIFF
--- a/agent/Containerfile.template
+++ b/agent/Containerfile.template
@@ -126,6 +126,9 @@ RUN pip3 install --no-cache-dir black flake8 pylint
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
+# Default tmux configuration for agent sessions
+COPY tmux.conf /root/.tmux.conf
+
 # Copy the daemon as a Python package so imports
 # (e.g. from agent.profiles) work correctly.
 COPY __init__.py agent/

--- a/agent/tmux.conf
+++ b/agent/tmux.conf
@@ -1,0 +1,18 @@
+# Default tmux configuration for agent dashboard sessions.
+# Agents run inside tmux for terminal stability, resize
+# handling, and scrollback persistence.
+
+# Enable mouse support so trackpad/mouse scrolling
+# navigates the tmux scrollback buffer instead of being
+# passed through to the agent (which interprets scroll
+# events as input history navigation).
+set -g mouse on
+
+# Eliminate the escape sequence delay so key combinations
+# (e.g. Escape followed by a letter) are sent immediately
+# rather than waiting for a potential multi-byte sequence.
+set -sg escape-time 0
+
+# Enable extended keys so modified keys (Shift+Enter, etc.)
+# are passed through correctly to agent TUIs.
+set -g extended-keys on


### PR DESCRIPTION
## Problem

With tmux-wrapped agent sessions (PR #95), trackpad/mouse scrolling navigates Pi's input history instead of scrolling the terminal output. This is because tmux defaults to mouse mode off, so scroll events pass through to the agent process.

## Fix

Add `agent/tmux.conf` copied to `/root/.tmux.conf` in the container:

- **`set -g mouse on`** — scroll events navigate the tmux scrollback buffer
- **`set -sg escape-time 0`** — eliminate input delay for key combinations
- **`set -g extended-keys on`** — pass modified keys (Shift+Enter, etc.) through to agent TUIs

## Testing

- Scroll with trackpad/mouse wheel in a terminal session — should scroll output, not input history
- Verify agent TUI rendering still works (colors, cursor movement)
- Verify Shift+Enter and other modified keys work in Pi sessions

## Related

- PR #95 — Phase 1 tmux wrapping
- #83 — tmux agent sessions tracking issue

Co-authored-by: Claude claude@anthropic.com