### PR TITLE
fix: patch agy settings.json at spawn time for telemetry

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -872,6 +872,38 @@ class HostDaemon:
         else:
             cmd = [tool]
 
+        # Patch spawn-time settings files before forking.
+        # Some agent tools (e.g. agy) read settings from
+        # JSON config files at startup, and those files
+        # may be on host volume mounts that override the
+        # container's built-in defaults.  spawn_settings
+        # ensures required keys are present without
+        # overwriting user customizations.
+        if profile and profile.spawn_settings:
+            for filepath, required_keys in profile.spawn_settings.items():
+                filepath = os.path.expanduser(filepath)
+                try:
+                    existing = {}
+                    if os.path.exists(filepath):
+                        with open(filepath, "r", encoding="utf-8") as f:
+                            existing = json.load(f)
+                    changed = False
+                    for key, value in required_keys.items():
+                        if key not in existing:
+                            existing[key] = value
+                            changed = True
+                    if changed:
+                        os.makedirs(
+                            os.path.dirname(filepath),
+                            exist_ok=True,
+                        )
+                        with open(filepath, "w", encoding="utf-8") as f:
+                            json.dump(existing, f, indent=2)
+                            f.write("\n")
+                        log.info(f"Patched spawn settings: " f"{filepath}")
+                except Exception as e:
+                    log.info(f"Failed to patch spawn settings " f"{filepath}: {e}")
+
         pid, fd = pty.fork()
         if pid == 0:  # Child process
             if full_path and os.path.exists(full_path):

--- a/agent/profiles.py
+++ b/agent/profiles.py
@@ -138,6 +138,7 @@ class AgentProfile:
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     sidecar: Optional[SidecarConfig] = None
     permission_patterns: List[str] = field(default_factory=list)
+    spawn_settings: Dict[str, Dict[str, object]] = field(default_factory=dict)
     provisioning: Optional[ProvisioningConfig] = None
 
     @property
@@ -250,6 +251,9 @@ def _parse_profile(data: dict) -> AgentProfile:
             ],
             passthrough_env=prov.get("passthrough_env", []),
         )
+
+    # Spawn settings — JSON files to patch at spawn time
+    profile.spawn_settings = data.get("spawn_settings", {})
 
     return profile
 

--- a/agent/profiles/agy.yaml
+++ b/agent/profiles/agy.yaml
@@ -36,6 +36,18 @@ env:
 # No auth gate — agy supports Google OAuth and API
 # keys. The CLI handles its own auth prompts.
 
+# Spawn-time settings — patch the host-mounted
+# settings.json to ensure required keys are present.
+# agy reads enableTelemetry from settings.json and
+# ignores the GEMINI_CLI_TELEMETRY_ENABLED env var.
+# allowNonWorkspaceAccess=false keeps agents scoped
+# to the project directory.  Only missing keys are
+# added — existing user values are preserved.
+spawn_settings:
+  ~/.gemini/antigravity-cli/settings.json:
+    enableTelemetry: true
+    allowNonWorkspaceAccess: false
+
 mcp:
   user_files:
     - ~/.gemini/antigravity-cli/settings.json


### PR DESCRIPTION
## Problem (#91)

Antigravity (agy) sessions report zero telemetry. TCP analysis confirmed no connections from agy to the OTLP receiver, despite `GEMINI_CLI_TELEMETRY_ENABLED=true` being set in the environment.

## Root Cause

agy reads `enableTelemetry` from `~/.gemini/antigravity-cli/settings.json` and this takes priority over environment variables. The host volume mount overlays any container-provisioned defaults, so the host's `settings.json` typically lacks `enableTelemetry` entirely.

## Fix

Add a generic `spawn_settings` profile field that specifies JSON files to patch at spawn time. Before forking the child process, the daemon reads each file, adds any **missing** required keys (preserving existing user values), and writes it back.

The agy profile uses this to ensure:
- `enableTelemetry: true` — required for OTLP export
- `allowNonWorkspaceAccess: false` — keeps agents scoped to the project directory

### Example profile YAML

```yaml
spawn_settings:
  ~/.gemini/antigravity-cli/settings.json:
    enableTelemetry: true
    allowNonWorkspaceAccess: false
```

The mechanism is generic — other profiles can reuse it for any host-mounted config file that needs spawn-time defaults.

## Changes

- `agent/profiles.py`: Add `spawn_settings` field to `AgentProfile`
- `agent/host_daemon.py`: Patch settings files before `pty.fork()`
- `agent/profiles/agy.yaml`: Add `spawn_settings` for `settings.json`

Fixes #91.

Co-authored-by: Claude claude@anthropic.com