### PR TITLE
docs: add task delegation guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,35 @@ This project is inspired by the following blog post:
 - **Language**: Use TypeScript for all new components and logic.
 - **Styling**: Use Tailwind CSS v4 utility classes. Custom CSS should only be used for overrides that Tailwind cannot express (e.g., third-party component styling).
 
+## Task Delegation
+
+When a `task` tool is available, use it proactively to
+delegate work to specialist sub-agents:
+
+- **explore** — use when you need to map unfamiliar
+  parts of the codebase, find symbols across modules,
+  or gather `path:line` evidence before making changes.
+- **scout** — use when the answer requires official
+  documentation, web research, API behavior, or
+  knowledge not found in the repository.
+- **general** — use for parallel units of work,
+  multi-step implementation tasks, or research that
+  may require edits to validate.
+- **reviewer** — use after non-trivial edits to get an
+  independent code review before presenting results.
+
+Delegate when:
+- The task involves multiple independent subtasks that
+  can run in parallel.
+- You need to research while simultaneously editing.
+- The work benefits from isolated context (e.g.,
+  exploring a subdirectory while the parent works on
+  another).
+- A code review would add confidence before committing.
+
+Do NOT delegate trivial tasks (1–3 tool calls, 1–2
+  files) — handle those directly.
+
 ## Workflow & Safety
 
 ### Research & Strategy


### PR DESCRIPTION
## Problem

Pi with the pi-task extension only spawns sub-agents when explicitly asked for parallel work. Claude Code delegates to sub-agents naturally because it's built into its system prompt. Pi reads `AGENTS.md` for project-level instructions but finds no guidance about when to delegate.

## Fix

Add a "Task Delegation" section to `AGENTS.md` that tells the model:
- Which agent types are available and when to use each
- When to delegate (parallel tasks, research + edit, code review)
- When NOT to delegate (trivial 1-3 tool call tasks)

This matches the `PROACTIVE` markers in pi-task's agent definitions and gives the model the project-level context it needs to delegate autonomously.

Co-authored-by: Claude claude@anthropic.com