### PR TITLE
feat: pi-task Agent rename workaround and setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,35 +31,6 @@ This project is inspired by the following blog post:
 - **Language**: Use TypeScript for all new components and logic.
 - **Styling**: Use Tailwind CSS v4 utility classes. Custom CSS should only be used for overrides that Tailwind cannot express (e.g., third-party component styling).
 
-## Task Delegation
-
-When a `task` tool is available, use it proactively to
-delegate work to specialist sub-agents:
-
-- **explore** — use when you need to map unfamiliar
-  parts of the codebase, find symbols across modules,
-  or gather `path:line` evidence before making changes.
-- **scout** — use when the answer requires official
-  documentation, web research, API behavior, or
-  knowledge not found in the repository.
-- **general** — use for parallel units of work,
-  multi-step implementation tasks, or research that
-  may require edits to validate.
-- **reviewer** — use after non-trivial edits to get an
-  independent code review before presenting results.
-
-Delegate when:
-- The task involves multiple independent subtasks that
-  can run in parallel.
-- You need to research while simultaneously editing.
-- The work benefits from isolated context (e.g.,
-  exploring a subdirectory while the parent works on
-  another).
-- A code review would add confidence before committing.
-
-Do NOT delegate trivial tasks (1–3 tool calls, 1–2
-  files) — handle those directly.
-
 ## Workflow & Safety
 
 ### Research & Strategy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,35 @@ This project is inspired by the following blog post:
 - **Language**: Use TypeScript for all new components and logic.
 - **Styling**: Use Tailwind CSS v4 utility classes. Custom CSS should only be used for overrides that Tailwind cannot express (e.g., third-party component styling).
 
+## Task Delegation
+
+When a `task` tool is available, use it proactively to
+delegate work to specialist sub-agents:
+
+- **explore** — use when you need to map unfamiliar
+  parts of the codebase, find symbols across modules,
+  or gather `path:line` evidence before making changes.
+- **scout** — use when the answer requires official
+  documentation, web research, API behavior, or
+  knowledge not found in the repository.
+- **general** — use for parallel units of work,
+  multi-step implementation tasks, or research that
+  may require edits to validate.
+- **reviewer** — use after non-trivial edits to get an
+  independent code review before presenting results.
+
+Delegate when:
+- The task involves multiple independent subtasks that
+  can run in parallel.
+- You need to research while simultaneously editing.
+- The work benefits from isolated context (e.g.,
+  exploring a subdirectory while the parent works on
+  another).
+- A code review would add confidence before committing.
+
+Do NOT delegate trivial tasks (1–3 tool calls, 1–2
+  files) — handle those directly.
+
 ## Workflow & Safety
 
 ### Research & Strategy

--- a/agent/pi-defaults/AGENTS.md
+++ b/agent/pi-defaults/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Task Delegation
 
-When a `task` tool is available, use it proactively to
-delegate work to specialist sub-agents:
+When an `Agent` tool is available, use it proactively
+to delegate work to specialist sub-agents:
 
 - **explore** — use when you need to map unfamiliar
   parts of the codebase, find symbols across modules,

--- a/agent/pi-defaults/AGENTS.md
+++ b/agent/pi-defaults/AGENTS.md
@@ -1,0 +1,30 @@
+# Global Agent Instructions
+
+## Task Delegation
+
+When a `task` tool is available, use it proactively to
+delegate work to specialist sub-agents:
+
+- **explore** — use when you need to map unfamiliar
+  parts of the codebase, find symbols across modules,
+  or gather `path:line` evidence before making changes.
+- **scout** — use when the answer requires official
+  documentation, web research, API behavior, or
+  knowledge not found in the repository.
+- **general** — use for parallel units of work,
+  multi-step implementation tasks, or research that
+  may require edits to validate.
+- **reviewer** — use after non-trivial edits to get an
+  independent code review before presenting results.
+
+Delegate when:
+- The task involves multiple independent subtasks that
+  can run in parallel.
+- You need to research while simultaneously editing.
+- The work benefits from isolated context (e.g.,
+  exploring a subdirectory while the parent works on
+  another).
+- A code review would add confidence before committing.
+
+Do NOT delegate trivial tasks (1–3 tool calls, 1–2
+files) — handle those directly.

--- a/agent/pi-defaults/README.md
+++ b/agent/pi-defaults/README.md
@@ -3,35 +3,56 @@
 This directory contains default configuration files for
 Pi coding agent sessions running in the dashboard.
 
-## Agent Overrides (`agents/`)
+## Setup
 
-These are agent definition overrides for the
+Run the setup script to install all Pi defaults:
+
+```bash
+./agent/pi-defaults/setup.sh
+```
+
+This copies agent overrides to `~/.pi/agents/`, installs
+the global `AGENTS.md`, and renames pi-task's tool from
+`task` to `Agent` for proactive delegation.
+
+## What's included
+
+### Agent Overrides (`agents/`)
+
+Agent definition overrides for the
 [pi-task](https://github.com/heyhuynhgiabuu/pi-task)
-sub-agent extension. They are based on pi-task's
-bundled agent definitions with one critical change:
-**the `model:` line is removed** so that sub-agents
-inherit the parent session's provider and model from
-`~/.pi/agent/settings.json`.
+sub-agent extension. Based on pi-task's bundled agent
+definitions with the `model:` line removed so that
+sub-agents inherit the parent session's provider and
+model from `~/.pi/agent/settings.json`.
 
 Without these overrides, pi-task's bundled agents
 default to `opencode-go/deepseek-v4-flash`, which
 fails if that provider isn't configured.
 
-### Installation
-
-Copy the agent overrides to your Pi user config
-directory (persisted via the `~/.pi` volume mount):
-
-```bash
-cp -r agent/pi-defaults/agents/ ~/.pi/agents/
-```
-
-Or for project-level overrides (applies only to a
-specific project):
-
-```bash
-cp -r agent/pi-defaults/agents/ /path/to/project/.pi/agents/
-```
-
 Pi-task's precedence: project agents > user agents >
 bundled agents.
+
+### Global AGENTS.md
+
+Installs `~/.pi/agent/AGENTS.md` with task delegation
+guidance that tells the model when and how to use
+sub-agents proactively.
+
+### pi-task Tool Rename (`task` → `Agent`)
+
+Claude (the model) is trained to proactively delegate
+to a tool called `Agent` (Claude Code's built-in
+sub-agent tool name). pi-task registers its tool as
+`task`, which the model treats as a generic tool and
+only uses when explicitly asked.
+
+The setup script renames the tool from `task` to
+`Agent` via a sed patch, causing the model to delegate
+autonomously. This is a workaround pending an upstream
+configuration option
+([heyhuynhgiabuu/pi-task#11](https://github.com/heyhuynhgiabuu/pi-task/issues/11)).
+
+> **Note:** The patch must be reapplied after upgrading
+> pi-task (`pi install npm:@heyhuynhgiabuu/pi-task`).
+> Run `setup.sh` again after upgrades.

--- a/agent/pi-defaults/setup.sh
+++ b/agent/pi-defaults/setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Setup Pi defaults for Agent Dashboard
+#
+# Installs agent overrides, global AGENTS.md, and
+# renames pi-task's tool from "task" to "Agent" for
+# proactive sub-agent delegation.
+#
+# Run after:
+#   - Fresh Pi extension installation
+#   - pi-task upgrades (pi install npm:@heyhuynhgiabuu/pi-task)
+#
+# Usage:
+#   ./agent/pi-defaults/setup.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PI_DIR="${HOME}/.pi/agent"
+PI_TASK_INDEX="${PI_DIR}/npm/node_modules/@heyhuynhgiabuu/pi-task/dist/index.js"
+
+echo "=== Pi Defaults Setup ==="
+
+# 1. Copy agent overrides
+echo "Installing agent overrides to ${PI_DIR}/../../agents/ ..."
+mkdir -p "${HOME}/.pi/agents"
+cp -r "${SCRIPT_DIR}/agents/"*.md "${HOME}/.pi/agents/"
+echo "  ✓ Copied explore, scout, general, reviewer"
+
+# 2. Install global AGENTS.md
+echo "Installing global AGENTS.md to ${PI_DIR}/ ..."
+cp "${SCRIPT_DIR}/AGENTS.md" "${PI_DIR}/AGENTS.md"
+echo "  ✓ Installed task delegation guidance"
+
+# 3. Rename pi-task tool from "task" to "Agent"
+if [ -f "${PI_TASK_INDEX}" ]; then
+    if grep -q 'name: "task"' "${PI_TASK_INDEX}"; then
+        sed -i 's/name: "task"/name: "Agent"/' "${PI_TASK_INDEX}"
+        echo "  ✓ Renamed pi-task tool: task → Agent"
+    elif grep -q 'name: "Agent"' "${PI_TASK_INDEX}"; then
+        echo "  ✓ pi-task tool already named Agent"
+    else
+        echo "  ⚠ Could not find tool name in pi-task index.js"
+    fi
+else
+    echo "  ⚠ pi-task not installed — skipping tool rename"
+    echo "    Install with: pi install npm:@heyhuynhgiabuu/pi-task"
+fi
+
+echo ""
+echo "Done. Restart Pi or run /reload to apply changes."

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -561,16 +561,20 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp npm:@heyhuynhgiabuu/pi-task
   - **reviewer** (proactive) — code review after
     non-trivial edits.
 
-  **Important:** pi-task's bundled agents default to
-  `opencode-go/deepseek-v4-flash`, which fails if
-  that provider isn't configured. Copy the dashboard's
-  agent overrides (which remove the hardcoded model so
-  sub-agents inherit from `settings.json`) to your Pi
-  user config:
+  **Setup required:** Run the setup script after
+  installing pi-task:
 
   ```bash
-  cp -r agent/pi-defaults/agents/ ~/.pi/agents/
+  ./agent/pi-defaults/setup.sh
   ```
+
+  This installs agent overrides (removes the hardcoded
+  `opencode-go` model so sub-agents inherit from
+  `settings.json`), a global `AGENTS.md` with
+  delegation guidance, and renames pi-task's tool from
+  `task` to `Agent` so the model delegates proactively
+  (see [heyhuynhgiabuu/pi-task#11](https://github.com/heyhuynhgiabuu/pi-task/issues/11)).
+  Re-run after pi-task upgrades.
 
   Set `PI_TASK_CHILD_NO_EXTENSIONS=1` in the Pi
   profile's env if sub-agents crash on startup due to


### PR DESCRIPTION
## Summary

Enable proactive sub-agent delegation in Pi sessions by renaming pi-task's tool from `task` to `Agent` and providing a setup script for all Pi defaults.

## Background

Claude (the model) is trained to proactively delegate to a tool called `Agent` — Claude Code's built-in sub-agent tool name. When pi-task registers as `task`, the model only delegates when explicitly asked. Renaming to `Agent` causes natural, proactive delegation matching Claude Code's behavior.

Validated by comparing identical prompts:
- **`task`**: Model only spawned sub-agents when explicitly asked
- **`Agent`**: Model proactively dispatched explore/scout/reviewer agents, waited for results, and synthesized responses

## Changes

### `agent/pi-defaults/setup.sh` (new)
One-command setup that:
1. Copies agent overrides to `~/.pi/agents/` (removes hardcoded model)
2. Installs global `~/.pi/agent/AGENTS.md` with delegation guidance
3. Renames pi-task tool from `task` to `Agent` via sed patch

Must be re-run after pi-task upgrades.

### `agent/pi-defaults/AGENTS.md` (new)
Global Pi instructions with task delegation guidance — tells the model when to use explore, scout, general, and reviewer agents proactively.

### `AGENTS.md`
Added Task Delegation section (project-level, supersedes PR #104).

### `docs/agent-profiles.md`
Updated pi-task setup instructions to reference `setup.sh`.

## Upstream

Feature request filed: [heyhuynhgiabuu/pi-task#11](https://github.com/heyhuynhgiabuu/pi-task/issues/11) — configurable tool name via env var, with `Agent` as recommended default.

Supersedes #104.

Co-authored-by: Claude claude@anthropic.com