### PR TITLE
perf/fix: tmux performance, mouse behavior, streaming, resize, and stability

### DIFF
--- a/agent/Containerfile.template
+++ b/agent/Containerfile.template
@@ -11,11 +11,21 @@ FROM registry.fedoraproject.org/fedora:42
 
 WORKDIR /app
 
-# Install base system packages and development tools
-RUN dnf install --setopt=install_weak_deps=False --setopt=retries=3 -y \
+# Add GitHub CLI repository configuration
+RUN printf '[gh-cli]\nname=GitHub CLI\nbaseurl=https://cli.github.com/packages/rpm\nenabled=1\ngpgcheck=1\ngpgkey=https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x23F3D4EA75716059\n' \
+    > /etc/yum.repos.d/gh-cli.repo
+
+# Install base system packages and development tools in a single DNF transaction.
+# Uses max_parallel_downloads=10 for faster RPM downloads and tsflags=nodocs to
+# skip documentation extraction during package installation.
+RUN dnf install --setopt=install_weak_deps=False \
+    --setopt=max_parallel_downloads=10 \
+    --setopt=tsflags=nodocs \
+    --setopt=retries=3 -y \
     bash \
     bash-completion \
     curl \
+    gh \
     nodejs \
     nodejs-full-i18n \
     npm \
@@ -68,12 +78,6 @@ RUN mkdir -p /etc/containers \
     && printf '[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
        >> /etc/containers/containers.conf
 
-# Install GitHub CLI
-RUN printf '[gh-cli]\nname=GitHub CLI\nbaseurl=https://cli.github.com/packages/rpm\nenabled=1\ngpgcheck=1\ngpgkey=https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x23F3D4EA75716059\n' \
-    > /etc/yum.repos.d/gh-cli.repo \
-    && dnf install --setopt=install_weak_deps=False --setopt=retries=3 -y gh \
-    && dnf clean all
-
 # Install Google Cloud CLI (required for Claude Code via Vertex AI)
 # Use direct tarball download with explicit architecture detection to avoid
 # the interactive installer script, which may modify shell profiles and
@@ -98,8 +102,9 @@ RUN curl -fsSL https://antigravity.google/cli/install.sh | bash \
 
 # ── Agent tool installations (profile-driven) ─────
 {% if npm_packages %}
-RUN npm install -g {{ npm_packages | join(' ') }}
+RUN npm install -g --no-audit --no-fund {{ npm_packages | join(' ') }}
 {% endif %}
+
 {% if pip_packages %}
 RUN pip3 install --no-cache-dir {{ pip_packages | join(' ') }}
 {% endif %}

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -242,33 +242,18 @@ class HostDaemon:
             cols = data.get("cols")
             rows = data.get("rows")
             if agent_id in self.agents and cols and rows:
-                # Resize the tmux window so the agent TUI
-                # redraws at the new dimensions.  Also
-                # resize the outer PTY so the kernel's
-                # line discipline matches.
+                # Resize the outer PTY only.  TIOCSWINSZ
+                # sends SIGWINCH to the tmux client, which
+                # forwards the size change to the tmux
+                # server automatically.  Do NOT also call
+                # tmux resize-window — that causes a
+                # redundant second full-screen redraw.
                 master_fd = self.agents[agent_id]["master_fd"]
                 size = struct.pack("HHHH", rows, cols, 0, 0)
                 try:
                     fcntl.ioctl(master_fd, termios.TIOCSWINSZ, size)
                 except Exception as e:
                     log.info(f"Failed to resize PTY {agent_id}: {e}")
-                try:
-                    subprocess.run(
-                        [
-                            "tmux",
-                            "resize-window",
-                            "-t",
-                            agent_id,
-                            "-x",
-                            str(cols),
-                            "-y",
-                            str(rows),
-                        ],
-                        capture_output=True,
-                        check=False,
-                    )
-                except Exception as e:
-                    log.info(f"Failed to resize tmux window" f" {agent_id}: {e}")
 
         @self.sio.on("spawn_agent", namespace="/terminal")
         async def on_spawn_agent(data):

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1049,7 +1049,7 @@ class HostDaemon:
             fds = [a["master_fd"] for a in self.agents.values()]
             try:
                 r, _, _ = await loop.run_in_executor(
-                    None, select.select, fds, [], [], 0.1
+                    None, select.select, fds, [], [], 0.02
                 )
             except ValueError:
                 self.cleanup_closed_agents()
@@ -1089,14 +1089,14 @@ class HostDaemon:
                         raw += chunk
 
                     # Strip tmux terminal capability queries
-                    # to prevent round-trip jitter.
-                    raw = _TMUX_QUERIES.sub(b"", raw)
-                    # Strip mouse tracking sequences so
-                    # xterm.js stays in normal mouse mode
-                    # (browser-native text selection).
-                    raw = _MOUSE_TRACKING.sub(b"", raw)
-                    if not raw:
-                        continue
+                    # and mouse tracking sequences.  Use a
+                    # fast byte scan before running the regex
+                    # to skip chunks that can't match.
+                    if b"\x1b[" in raw or b"\x1b]" in raw:
+                        raw = _TMUX_QUERIES.sub(b"", raw)
+                        raw = _MOUSE_TRACKING.sub(b"", raw)
+                        if not raw:
+                            continue
 
                     # Buffer output during the startup
                     # window so tmux's initialization bursts
@@ -1126,31 +1126,30 @@ class HostDaemon:
                         # Check for permission prompts.
                         # Strip ANSI escapes before matching to
                         # avoid false positives on escape codes.
-                        # A match sets a candidate timestamp;
-                        # the status poll promotes it to
-                        # permission_waiting after the agent
-                        # has been idle for PERMISSION_IDLE_SECONDS.
-                        stripped = _ANSI_ESCAPE.sub("", decoded_data)
+                        # Only run the expensive regex+search
+                        # when the chunk contains a newline
+                        # (prompts always end with one).
                         now = time.monotonic()
-                        if any(p.search(stripped) for p in self.permission_patterns):
-                            info["permission_candidate"] = now
+                        if "\n" in decoded_data or "?" in decoded_data:
+                            stripped = _ANSI_ESCAPE.sub("", decoded_data)
+                            if any(
+                                p.search(stripped) for p in self.permission_patterns
+                            ):
+                                info["permission_candidate"] = now
                         # New output clears permission_waiting
                         # since the agent is actively producing
                         # output (not waiting for input).
                         if info.get("permission_waiting"):
                             info["permission_waiting"] = False
 
-                        try:
-                            await self.sio.emit(
-                                "terminal_output",
-                                {
-                                    "sid": agent_id,
-                                    "output": decoded_data,
-                                },
-                                namespace="/terminal",
-                            )
-                        except Exception:
-                            pass
+                        # Accumulate output in a per-agent
+                        # buffer.  A separate flush coroutine
+                        # sends it periodically, avoiding both
+                        # per-chunk await latency (slow
+                        # streaming) and unbounded create_task
+                        # accumulation (resize starvation).
+                        ob = info.get("output_buf", "")
+                        info["output_buf"] = ob + decoded_data
                 except OSError:
                     self.close_agent(agent_id)
             # When data was relayed, yield to the event
@@ -1160,6 +1159,37 @@ class HostDaemon:
             # nothing) we still fall through quickly since
             # select itself already waited up to 0.1 s.
             await asyncio.sleep(0)
+
+    async def flush_output(self):
+        """Periodically flushes per-agent output buffers.
+
+        Runs as a separate task alongside watch_agents.
+        Output is accumulated in info['output_buf'] by the
+        read loop and flushed here every 15ms.  This avoids
+        both per-chunk await latency (slow streaming) and
+        unbounded create_task accumulation (event loop
+        starvation during resize).
+        """
+        while self.running:
+            if not self.agents or not self.sio.connected:
+                await asyncio.sleep(0.05)
+                continue
+            for agent_id, info in list(self.agents.items()):
+                buf = info.get("output_buf", "")
+                if buf:
+                    info["output_buf"] = ""
+                    try:
+                        await self.sio.emit(
+                            "terminal_output",
+                            {
+                                "sid": agent_id,
+                                "output": buf,
+                            },
+                            namespace="/terminal",
+                        )
+                    except Exception:
+                        pass
+            await asyncio.sleep(0.015)
 
     def close_agent(self, agent_id: str):
         """Closes the PTY fd, kills the tmux session, and
@@ -1946,6 +1976,9 @@ class HostDaemon:
             self.status_task = asyncio.create_task(
                 self._run_task("status", self.update_agent_status)
             )
+            self.flush_task = asyncio.create_task(
+                self._run_task("flush", self.flush_output)
+            )
 
             await asyncio.gather(
                 self.watcher_task,
@@ -1953,6 +1986,7 @@ class HostDaemon:
                 self.otlp_task,
                 self.git_task,
                 self.status_task,
+                self.flush_task,
             )
         except asyncio.CancelledError:
             pass

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -72,6 +72,17 @@ _TMUX_QUERIES = re.compile(
     rb"|\x1b\]11;\?\x1b\\"  # Background color query
 )
 
+# Mouse tracking escape sequences that tmux sends when
+# mouse mode is enabled.  Stripping these from the
+# output prevents xterm.js from entering application
+# mouse mode, so the browser handles text selection,
+# right-click, and copy/paste natively.  The frontend
+# sends synthesized SGR mouse wheel sequences for
+# scroll, which tmux processes normally.
+_MOUSE_TRACKING = re.compile(
+    rb"\x1b\[\?(?:1000|1002|1003|1004|1005|1006|1015|1016)[hl]"
+)
+
 # Seconds to buffer output after agent spawn before
 # relaying to the frontend.  tmux emits several bursts
 # of startup escape sequences over ~300 ms; buffering
@@ -1080,6 +1091,10 @@ class HostDaemon:
                     # Strip tmux terminal capability queries
                     # to prevent round-trip jitter.
                     raw = _TMUX_QUERIES.sub(b"", raw)
+                    # Strip mouse tracking sequences so
+                    # xterm.js stays in normal mouse mode
+                    # (browser-native text selection).
+                    raw = _MOUSE_TRACKING.sub(b"", raw)
                     if not raw:
                         continue
 
@@ -1138,7 +1153,13 @@ class HostDaemon:
                             pass
                 except OSError:
                     self.close_agent(agent_id)
-            await asyncio.sleep(0.01)
+            # When data was relayed, yield to the event
+            # loop without wall-clock delay so other
+            # coroutines run but the next read starts
+            # immediately.  On idle cycles (select returned
+            # nothing) we still fall through quickly since
+            # select itself already waited up to 0.1 s.
+            await asyncio.sleep(0)
 
     def close_agent(self, agent_id: str):
         """Closes the PTY fd, kills the tmux session, and

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -2001,6 +2001,27 @@ class HostDaemon:
             self.status_task.cancel()
 
 
+def _reap_zombies():
+    """Reap zombie child processes.
+
+    The daemon runs as PID 1 inside the container, which
+    makes it the init process responsible for reaping
+    orphaned children.  Agent tools (git, bash, compilers)
+    spawn child processes that may outlive their parent
+    and get reparented to PID 1.  Without reaping, these
+    accumulate as zombies and eventually exhaust the
+    container's PID limit (typically 2048 in rootless
+    Podman).
+    """
+    while True:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+            if pid == 0:
+                break
+        except ChildProcessError:
+            break
+
+
 async def main():
     """Entry point: reads config from env vars and runs the daemon."""
     server_url = os.getenv("DASHBOARD_URL", "http://localhost:8000")
@@ -2012,6 +2033,10 @@ async def main():
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, daemon.stop)
+    # Reap zombie children automatically.  SIGCHLD fires
+    # whenever a child process exits; the handler calls
+    # waitpid() in a loop to collect all finished children.
+    loop.add_signal_handler(signal.SIGCHLD, _reap_zombies)
     await daemon.run()
 
 

--- a/agent/pi-defaults/README.md
+++ b/agent/pi-defaults/README.md
@@ -39,20 +39,18 @@ Installs `~/.pi/agent/AGENTS.md` with task delegation
 guidance that tells the model when and how to use
 sub-agents proactively.
 
-### pi-task Tool Rename (`task` → `Agent`)
+### pi-task Tool Name (`task` → `Agent`)
 
 Claude (the model) is trained to proactively delegate
 to a tool called `Agent` (Claude Code's built-in
-sub-agent tool name). pi-task registers its tool as
-`task`, which the model treats as a generic tool and
-only uses when explicitly asked.
+sub-agent tool name). pi-task defaults to `task`,
+which the model treats as a generic tool and only uses
+when explicitly asked.
 
-The setup script renames the tool from `task` to
-`Agent` via a sed patch, causing the model to delegate
-autonomously. This is a workaround pending an upstream
-configuration option
-([heyhuynhgiabuu/pi-task#11](https://github.com/heyhuynhgiabuu/pi-task/issues/11)).
+The Pi profile sets `PI_TASK_TOOL_NAME=Agent` in its
+env vars, which pi-task (>= 0.3.5) reads at startup.
+This causes the model to delegate autonomously,
+matching Claude Code's native sub-agent behavior.
 
-> **Note:** The patch must be reapplied after upgrading
-> pi-task (`pi install npm:@heyhuynhgiabuu/pi-task`).
-> Run `setup.sh` again after upgrades.
+No manual patching is needed — the env var is injected
+automatically by the daemon at spawn time.

--- a/agent/pi-defaults/setup.sh
+++ b/agent/pi-defaults/setup.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # Setup Pi defaults for Agent Dashboard
 #
-# Installs agent overrides, global AGENTS.md, and
-# renames pi-task's tool from "task" to "Agent" for
+# Installs agent overrides and global AGENTS.md for
 # proactive sub-agent delegation.
+#
+# The pi-task tool rename (task → Agent) is now handled
+# natively via the PI_TASK_TOOL_NAME env var in the Pi
+# profile (pi.yaml), so no sed patch is needed.
 #
 # Run after:
 #   - Fresh Pi extension installation
@@ -16,35 +19,47 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PI_DIR="${HOME}/.pi/agent"
-PI_TASK_INDEX="${PI_DIR}/npm/node_modules/@heyhuynhgiabuu/pi-task/dist/index.js"
 
 echo "=== Pi Defaults Setup ==="
 
 # 1. Copy agent overrides
-echo "Installing agent overrides to ${PI_DIR}/../../agents/ ..."
+echo "Installing agent overrides to ~/.pi/agents/ ..."
 mkdir -p "${HOME}/.pi/agents"
 cp -r "${SCRIPT_DIR}/agents/"*.md "${HOME}/.pi/agents/"
 echo "  ✓ Copied explore, scout, general, reviewer"
 
 # 2. Install global AGENTS.md
 echo "Installing global AGENTS.md to ${PI_DIR}/ ..."
+mkdir -p "${PI_DIR}"
 cp "${SCRIPT_DIR}/AGENTS.md" "${PI_DIR}/AGENTS.md"
 echo "  ✓ Installed task delegation guidance"
 
-# 3. Rename pi-task tool from "task" to "Agent"
+# 3. Patch pi-task v0.3.5 getAllTools() crash
+# pi-task v0.3.5 calls pi.getAllTools() during
+# extension loading, before the runtime is
+# initialized. Pi rejects this with "Action methods
+# cannot be called during extension loading".
+# Patch out the collision check until upstream fixes
+# this. Tracking: heyhuynhgiabuu/pi-task#13
+PI_TASK_INDEX="${PI_DIR}/npm/node_modules/@heyhuynhgiabuu/pi-task/dist/index.js"
 if [ -f "${PI_TASK_INDEX}" ]; then
-    if grep -q 'name: "task"' "${PI_TASK_INDEX}"; then
-        sed -i 's/name: "task"/name: "Agent"/' "${PI_TASK_INDEX}"
-        echo "  ✓ Renamed pi-task tool: task → Agent"
-    elif grep -q 'name: "Agent"' "${PI_TASK_INDEX}"; then
-        echo "  ✓ pi-task tool already named Agent"
+    if grep -q 'pi.getAllTools' "${PI_TASK_INDEX}"; then
+        sed -i '/pi\.getAllTools/,/^[[:space:]]*}/s/^/\/\//' \
+            "${PI_TASK_INDEX}"
+        echo "  ✓ Patched out getAllTools() collision" \
+            "check (pi-task#13)"
     else
-        echo "  ⚠ Could not find tool name in pi-task index.js"
+        echo "  ✓ pi-task getAllTools() already patched"
     fi
 else
-    echo "  ⚠ pi-task not installed — skipping tool rename"
-    echo "    Install with: pi install npm:@heyhuynhgiabuu/pi-task"
+    echo "  ⚠ pi-task not installed — skipping patch"
+    echo "    Install with:" \
+        "pi install npm:@heyhuynhgiabuu/pi-task"
 fi
 
 echo ""
 echo "Done. Restart Pi or run /reload to apply changes."
+echo ""
+echo "Note: pi-task tool rename (task → Agent) is handled"
+echo "by the PI_TASK_TOOL_NAME env var in the Pi profile."
+echo "Requires pi-task >= 0.3.5."

--- a/agent/profiles/pi.yaml
+++ b/agent/profiles/pi.yaml
@@ -37,6 +37,11 @@ env:
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/json"
   OTEL_SERVICE_NAME: "{agent_id}"
   PI_OTEL_METRICS: "1"
+  # pi-task v0.3.5 reads this env var to set the
+  # registered tool name. "Agent" triggers proactive
+  # sub-agent delegation in Claude-based models.
+  # See: heyhuynhgiabuu/pi-task#11
+  PI_TASK_TOOL_NAME: "Agent"
 
 # No auth gate — Pi is provider-agnostic and
 # handles its own provider selection and auth.

--- a/agent/tmux.conf
+++ b/agent/tmux.conf
@@ -27,6 +27,19 @@ set -g extended-keys-format csi-u
 # mouse wheel (handled by the dashboard frontend).
 set -g history-limit 10000
 
+# --- Window sizing ---
+# Size the window to the largest connected client so
+# no client gets clipped.  With "latest" (default),
+# multiple clients cause resize fighting as each one
+# triggers a resize to its own dimensions.
+set -g window-size largest
+
+# aggressive-resize allows different windows in the
+# same session to have different sizes based on the
+# clients viewing them.  Avoids shrinking all windows
+# to the smallest client.
+set -g aggressive-resize on
+
 # --- Performance tuning ---
 # Agent sessions are headless (output is relayed to the
 # frontend via Socket.IO).  Disable features that add

--- a/agent/tmux.conf
+++ b/agent/tmux.conf
@@ -2,10 +2,12 @@
 # Agents run inside tmux for terminal stability, resize
 # handling, and scrollback persistence.
 
-# Enable mouse support so trackpad/mouse scrolling
-# navigates the tmux scrollback buffer instead of being
-# passed through to the agent (which interprets scroll
-# events as input history navigation).
+# Mouse mode ON so tmux handles scroll events for its
+# scrollback buffer.  The daemon strips mouse tracking
+# escape sequences from the output stream before they
+# reach xterm.js, so the browser handles text selection
+# and right-click natively.  The frontend sends
+# synthesized SGR mouse wheel sequences for scrolling.
 set -g mouse on
 
 # Eliminate the escape sequence delay so key combinations
@@ -13,6 +15,45 @@ set -g mouse on
 # rather than waiting for a potential multi-byte sequence.
 set -sg escape-time 0
 
-# Enable extended keys so modified keys (Shift+Enter, etc.)
-# are passed through correctly to agent TUIs.
+# Enable extended keys in CSI-u format so modified keys
+# (Shift+Enter, etc.) are passed through correctly to
+# agent TUIs.  Pi requires csi-u format specifically.
 set -g extended-keys on
+set -g extended-keys-format csi-u
+
+# --- Scrollback ---
+# Large scrollback buffer for long agent sessions.
+# Users can scroll through agent output history via
+# mouse wheel (handled by the dashboard frontend).
+set -g history-limit 10000
+
+# --- Performance tuning ---
+# Agent sessions are headless (output is relayed to the
+# frontend via Socket.IO).  Disable features that add
+# rendering overhead or produce extra escape sequences.
+
+# Disable automatic window renaming.  tmux polls the
+# running process title to rename windows — unnecessary
+# when the session is headless.
+set -g automatic-rename off
+set -g allow-rename off
+
+# Disable activity/bell monitoring — these trigger
+# internal processing and visual escape sequences.
+set -g monitor-activity off
+set -g monitor-bell off
+set -g visual-activity off
+set -g visual-bell off
+set -g visual-silence off
+
+# --- Pane focus ---
+# When pi-task spawns a subagent via tmux split-window,
+# focus jumps to the new pane.  This hook immediately
+# returns focus to the previous (parent) pane so the
+# user's view stays on the original agent.
+set-hook -g after-split-window "select-pane -l"
+
+# --- Clipboard ---
+# Enable OSC 52 clipboard passthrough so applications
+# inside tmux can write to the system clipboard.
+set -g set-clipboard on

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -570,11 +570,14 @@ pi install npm:pi-otel npm:@0xkobold/pi-mcp npm:@heyhuynhgiabuu/pi-task
 
   This installs agent overrides (removes the hardcoded
   `opencode-go` model so sub-agents inherit from
-  `settings.json`), a global `AGENTS.md` with
-  delegation guidance, and renames pi-task's tool from
-  `task` to `Agent` so the model delegates proactively
-  (see [heyhuynhgiabuu/pi-task#11](https://github.com/heyhuynhgiabuu/pi-task/issues/11)).
-  Re-run after pi-task upgrades.
+  `settings.json`) and a global `AGENTS.md` with
+  delegation guidance. Re-run after pi-task upgrades.
+
+  The Pi profile also sets `PI_TASK_TOOL_NAME=Agent`
+  to rename the tool from `task` to `Agent`, which
+  causes the model to delegate proactively (requires
+  pi-task >= 0.3.5). This is automatic — no manual
+  configuration needed.
 
   Set `PI_TASK_CHILD_NO_EXTENSIONS=1` in the Pi
   profile's env if sub-agents crash on startup due to

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -220,6 +220,17 @@ targeted resize (`tmux resize-window`) and cleanup
 (`tmux kill-session`). tmux is included in the
 container image.
 
+### Process Management
+
+The daemon runs as **PID 1** inside the container,
+making it the init process. Agent tools (git, bash,
+compilers, subagents) spawn child processes that may
+outlive their parent and get reparented to PID 1.
+The daemon registers a `SIGCHLD` handler that reaps
+these orphaned processes automatically, preventing
+zombie accumulation that would otherwise exhaust the
+container's PID limit.
+
 ## Included Tools
 
 The daemon container bundles the following tools:

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -255,6 +255,14 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
     // after the debounce settles — no streaming deferral,
     // which could block fits indefinitely under high
     // latency and cause black screens.
+    // Track last-sent dimensions to deduplicate resize
+    // events.  When the browser pauses JS during a window
+    // drag, debounce timers freeze and all fire at once on
+    // resume — sending many identical resize events that
+    // each trigger a full tmux redraw.
+    let lastSentCols = 0;
+    let lastSentRows = 0;
+
     const performFit = () => {
       if (!terminalRef.current) return;
       try {
@@ -263,7 +271,12 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
         if (wasAtBottom) {
           term.scrollToBottom();
         }
-        if (socketRef.current?.connected) {
+        if (
+          socketRef.current?.connected &&
+          (term.cols !== lastSentCols || term.rows !== lastSentRows)
+        ) {
+          lastSentCols = term.cols;
+          lastSentRows = term.rows;
           socketRef.current.emit('terminal_resize', {
             sid: agentId,
             cols: term.cols,
@@ -276,7 +289,7 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
     };
 
     let resizeTimer: ReturnType<typeof setTimeout> | null = null;
-    const RESIZE_DEBOUNCE_MS = 150;
+    const RESIZE_DEBOUNCE_MS = 500;
     const debouncedFit = () => {
       if (resizeTimer) clearTimeout(resizeTimer);
       resizeTimer = setTimeout(performFit, RESIZE_DEBOUNCE_MS);
@@ -426,11 +439,43 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
     });
     socketRef.current = socket;
 
+    // Track disconnect time so we can detect brief
+    // interruptions (e.g. browser pausing JS during
+    // window drag-resize) vs real outages.
+    let disconnectedAt: number | null = null;
+    const BRIEF_DISCONNECT_MS = 30000;
+
+    socket.on('disconnect', () => {
+      disconnectedAt = Date.now();
+    });
+
     socket.on('connect', () => {
+      const wasBrief =
+        disconnectedAt !== null &&
+        Date.now() - disconnectedAt < BRIEF_DISCONNECT_MS;
+      disconnectedAt = null;
+
+      if (wasBrief) {
+        // Brief disconnect (e.g. browser paused JS during
+        // window drag-resize).  The terminal still has its
+        // content.  Do NOT emit join_room — that triggers
+        // request_history on the backend, and the history
+        // chunks would be written on top of existing
+        // content through the live output path.  Just send
+        // a resize so tmux adapts to any new dimensions.
+        isReplaying.current = false;
+        performFit();
+        return;
+      }
+
+      // Full reconnect — replay history.
       isReplaying.current = true;
       historyBuffer = [];
-      socket.emit('join_room', { room: agentId });
+      // Send resize BEFORE joining the room so tmux
+      // has the correct dimensions before history is
+      // replayed.
       performFit();
+      socket.emit('join_room', { room: agentId });
 
       // Detect stale sessions: if history never completes
       // within 5s, the daemon likely no longer has this agent
@@ -456,7 +501,6 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
         }
         isReplaying.current = false;
         replayEndTime = Date.now();
-        performFit();
       }
     });
 

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -357,6 +357,46 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
       });
     }
 
+    // --- Mouse wheel scrolling ---
+    // tmux has mouse mode ON for scroll handling, but
+    // the daemon strips mouse tracking escape sequences
+    // from the output stream so xterm.js never enters
+    // application mouse mode.  This means the browser
+    // handles text selection and right-click natively.
+    //
+    // Since xterm.js doesn't know about mouse tracking,
+    // wheel events stay in the browser.  We intercept
+    // them and send synthesized SGR mouse wheel escape
+    // sequences to tmux via Socket.IO.  tmux processes
+    // these as scroll events in its scrollback buffer.
+    //
+    // SGR (mode 1006) mouse wheel format:
+    //   \x1b[<64;col;rowM  = wheel up
+    //   \x1b[<65;col;rowM  = wheel down
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      if (!socketRef.current?.connected) return;
+      const lines = Math.round(e.deltaY / LINE_HEIGHT_PX);
+      if (lines === 0) return;
+      // Send SGR mouse wheel sequences — one per line,
+      // capped to avoid flooding the PTY.
+      const button = lines > 0 ? 65 : 64; // down : up
+      const count = Math.min(Math.abs(lines), 10);
+      let input = '';
+      for (let i = 0; i < count; i++) {
+        input += `\x1b[<${button};1;1M`;
+      }
+      socketRef.current.emit('terminal_input', {
+        target_sid: agentId,
+        input,
+      });
+    };
+    if (screenEl) {
+      screenEl.addEventListener('wheel', onWheel, {
+        passive: false,
+      });
+    }
+
     // --- Output batching ---
     // Buffer rapid successive terminal_output events and
     // flush them in a single term.write() per animation
@@ -498,6 +538,7 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
         screenEl.removeEventListener('touchstart', onTouchStart);
         screenEl.removeEventListener('touchmove', onTouchMove);
         screenEl.removeEventListener('touchend', onTouchEnd);
+        screenEl.removeEventListener('wheel', onWheel);
       }
       socket.disconnect();
       term.dispose();


### PR DESCRIPTION
## Summary

Performance tuning, mouse behavior, resize handling, and stability fixes for tmux-wrapped agent sessions. Squashed from 18 commits into 5 logical groups.

## Commits

### 1. `e71d488` feat: tmux configuration, mouse behavior, and Pi integration

**tmux.conf**: mouse on (tracking stripped by daemon for native browser selection), 10K scrollback, escape-time 0, extended-keys csi-u, window-size largest, aggressive-resize, OSC 52 clipboard, after-split-window focus hook.

**Daemon**: strip mouse tracking sequences (`_MOUSE_TRACKING` regex) from output so xterm.js never enters app mouse mode. TIOCSWINSZ-only resize (removed redundant `tmux resize-window`).

**Frontend**: wheel event handler sends synthesized SGR mouse sequences for tmux scrollback navigation.

**Pi profile**: `PI_TASK_TOOL_NAME=Agent` env var for proactive sub-agent delegation (pi-task >= 0.3.5).

### 2. `bb889c9` perf: buffered output flush with I/O optimizations

Replace per-chunk `await sio.emit()` with producer/consumer pattern: watch_agents accumulates output in per-agent string buffers, flush_output task sends every 15ms. Also: select() timeout 100ms→20ms, fast-path byte scan before regex, lazy permission prompt detection.

### 3. `8612ca2` fix: resize and reconnect handling

Send resize before history replay (eliminates truncated-width double-scroll). Deduplicate resize events with lastSentCols/lastSentRows tracking. Skip join_room on brief Socket.IO disconnects (< 30s) to avoid history replay during window drag-resize.

### 4. `fda02ec` fix: reap zombie processes (#108)

SIGCHLD handler calls `waitpid(-1, WNOHANG)` to reap orphaned children. The daemon is PID 1; without this, agent tool processes (git, bash, compilers) accumulate as zombies and exhaust the cgroup PID limit. Includes process management documentation in host-daemon.md.

### 5. `cb86eed` Optimize Containerfile.template for parallel builds

## Known Limitation

Long-running agent sessions (1hr+) experience 12-20 second resize delays. Fresh sessions and bash agents resize instantly. See #110 for investigation details. This is caused by the agent TUI's complex redraw being processed through tmux's terminal emulation layer.

## Fixes

- Fixes #108 (zombie process accumulation)

## Testing

- Verify mouse scroll navigates tmux scrollback (10K lines)
- Verify text highlighting and copy/paste work natively (both clipboards)
- Verify right-click shows browser context menu
- Verify no zombie processes after extended usage
- Verify streaming text display is responsive
- Verify sub-agent pane focus stays on parent
- Verify Pi extended-keys warning is gone

Co-authored-by: Claude claude@anthropic.com