### PR TITLE
fix: telemetry token/cost accounting for Pi and Antigravity (#90)

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1344,6 +1344,8 @@ class HostDaemon:
         for key in (
             "cache_creation_tokens",
             "gen_ai.usage.cache_creation_input_tokens",
+            # pi-otel also emits cache_write_input_tokens
+            "gen_ai.usage.cache_write_input_tokens",
         ):
             val = attrs.get(key)
             if val is not None:
@@ -1354,10 +1356,29 @@ class HostDaemon:
         else:
             cache_tokens = None
 
+        # Span attributes carry per-request token counts
+        # (pi-otel) or cumulative totals (Claude Code logs).
+        # Accumulate into _span_* tracking keys so the
+        # per-request values from pi-otel sum correctly.
+        # The metric-based path (cumulative histograms)
+        # writes to input_tokens / output_tokens directly
+        # and will supersede these when active.
         if input_tokens is not None or output_tokens is not None:
-            total = (input_tokens or 0) + (output_tokens or 0) + (cache_tokens or 0)
-            if total > tel.get("tokens", 0):
-                tel["tokens"] = total
+            inp = input_tokens or 0
+            out = output_tokens or 0
+            cch = cache_tokens or 0
+            tel["_span_input_tokens"] = tel.get("_span_input_tokens", 0) + inp
+            tel["_span_output_tokens"] = tel.get("_span_output_tokens", 0) + out
+            tel["_span_cache_tokens"] = tel.get("_span_cache_tokens", 0) + cch
+            # Use span-accumulated totals as floor;
+            # metric-reported values win when higher.
+            span_total = (
+                tel["_span_input_tokens"]
+                + tel["_span_output_tokens"]
+                + tel["_span_cache_tokens"]
+            )
+            if span_total > tel.get("tokens", 0):
+                tel["tokens"] = span_total
                 changed = True
 
         # Track input_tokens as context_tokens — this is
@@ -1369,14 +1390,19 @@ class HostDaemon:
             tel["context_tokens"] = input_tokens
             changed = True
 
-        # Cost — pi-otel puts cumulative session cost on
-        # pi.llm_request span attributes as pi.cost.usd.
+        # Cost — pi-otel puts per-request cost on each
+        # pi.llm_request span as pi.cost.usd. Accumulate
+        # with += since each span represents a single API
+        # call. The _span_cost_usd tracker prevents the
+        # metric path (cumulative) from conflicting.
         cost = attrs.get("pi.cost.usd")
         if cost is not None:
             cost_f = float(cost)
-            if cost_f > tel.get("cost_usd", 0.0):
-                tel["cost_usd"] = cost_f
-                changed = True
+            if cost_f > 0:
+                tel["_span_cost_usd"] = tel.get("_span_cost_usd", 0.0) + cost_f
+                if tel["_span_cost_usd"] > tel.get("cost_usd", 0.0):
+                    tel["cost_usd"] = tel["_span_cost_usd"]
+                    changed = True
 
         # Current activity — extract the latest tool/function
         # name from span or log attributes.  Gemini uses
@@ -1442,7 +1468,13 @@ class HostDaemon:
         svc = res_attrs.get("service.name", "") or ""
         all_vals = " ".join(str(v) for v in res_attrs.values() if v).lower()
 
-        if "gemini" in svc.lower() or "gemini" in all_vals:
+        if "antigravity" in svc.lower() or "agy" in all_vals:
+            tool_hint = "agy"
+        elif "gemini" in svc.lower() or "gemini" in all_vals:
+            # Antigravity (agy) is built on Gemini CLI and
+            # shares its telemetry namespace.  Check for agy
+            # agents first so "gemini" in resource attrs
+            # can fall back to matching agy sessions.
             tool_hint = "gemini"
         elif "claude" in svc.lower() or "claude" in all_vals:
             tool_hint = "claude"
@@ -1450,10 +1482,15 @@ class HostDaemon:
             tool_hint = "pi"
 
         if tool_hint:
+            # Build candidate list.  When the hint is
+            # "gemini", also include "agy" agents since
+            # Antigravity shares Gemini's OTLP namespace
+            # and resource attributes.
+            match_tools = {"gemini", "agy"} if tool_hint == "gemini" else {tool_hint}
             candidates = [
                 (aid, info)
                 for aid, info in self.agents.items()
-                if info.get("tool") == tool_hint
+                if info.get("tool") in match_tools
             ]
             if len(candidates) == 1:
                 return candidates[0][0]

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -909,6 +909,18 @@ class HostDaemon:
             env["TERM"] = "xterm-256color"
             env["COLORTERM"] = "truecolor"
 
+            # Remove stale OTEL env vars inherited from
+            # the daemon's own process environment. The
+            # daemon may run inside a tmux session that
+            # was spawned with a previous agent's OTEL
+            # config (e.g. OTEL_SERVICE_NAME from a Pi
+            # profile). Without this cleanup, agents
+            # whose profiles don't explicitly set these
+            # vars inherit incorrect values.
+            for key in list(env):
+                if key.startswith("OTEL_") or key.startswith("PI_OTEL"):
+                    del env[key]
+
             # Inject OpenTelemetry standard configuration
             env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{self.otlp_port}"
             env["OTEL_RESOURCE_ATTRIBUTES"] = f"service.name={agent_id}"

--- a/agent/profiles/agy.yaml
+++ b/agent/profiles/agy.yaml
@@ -3,6 +3,13 @@
 # June 18, 2026 for free/personal users.
 #
 # Requires agy >= 1.0.12 for --add-dir and --continue.
+#
+# OTLP telemetry: NOT SUPPORTED as of agy v1.0.15.
+# agy sends telemetry only to Google's internal
+# BusinessAI gRPC endpoints — it does not read
+# OTEL_* or GEMINI_TELEMETRY_* env vars and does
+# not export OTLP traces, metrics, or logs.
+# Tracked upstream: google-antigravity/antigravity-cli#366
 name: agy
 display_name: Antigravity
 color: cyan
@@ -19,18 +26,7 @@ commands:
   # Falls back to a new project if no history exists.
   resume: ["bash", "-c", "agy --continue --add-dir . || agy --new-project --add-dir ."]
 
-# Telemetry env vars — agy is built on the Gemini CLI
-# codebase and still honors the GEMINI_TELEMETRY_*
-# env vars for OTLP export (verified via binary
-# analysis of v1.0.15). The standard OTEL_* vars are
-# injected by the daemon automatically.
 env:
-  GEMINI_CLI_TELEMETRY_ENABLED: "true"
-  GEMINI_TELEMETRY_ENABLED: "true"
-  GEMINI_TELEMETRY_OTLP_ENDPOINT: "http://127.0.0.1:{otlp_port}"
-  GEMINI_TELEMETRY_OTLP_PROTOCOL: "http"
-  GEMINI_TELEMETRY_USE_COLLECTOR: "true"
-  GEMINI_TELEMETRY_TARGET: "local"
   AGY_CLI_HIDE_ACCOUNT_INFO: "1"
 
 # No auth gate — agy supports Google OAuth and API
@@ -38,34 +34,20 @@ env:
 
 # Spawn-time settings — patch the host-mounted
 # settings.json to ensure required keys are present.
-# agy reads enableTelemetry from settings.json and
-# ignores the GEMINI_CLI_TELEMETRY_ENABLED env var.
 # allowNonWorkspaceAccess=false keeps agents scoped
 # to the project directory.  Only missing keys are
 # added — existing user values are preserved.
 spawn_settings:
   ~/.gemini/antigravity-cli/settings.json:
-    enableTelemetry: true
     allowNonWorkspaceAccess: false
 
 mcp:
   user_files:
     - ~/.gemini/antigravity-cli/settings.json
 
-# Telemetry mappings — agy shares Gemini CLI's OTLP
-# metric namespace (devtools.cider.agent.* internally,
-# exported as gemini_cli.* via the OTLP bridge).
-telemetry:
-  token_metrics:
-    - gemini_cli.token.usage
-  activity_metrics:
-    - gemini_cli.tool.call.count
-    - gemini_cli.tool.call.latency
-  runtime_metric:
-    name: gemini_cli.agent.duration
-    unit: milliseconds
-  excluded_metrics:
-    - gen_ai.client.token.usage
+# No telemetry section — agy does not support OTLP.
+# Token/cost/model data is unavailable until
+# google-antigravity/antigravity-cli#366 is resolved.
 
 permission_patterns:
   - "Allow .+ to run"
@@ -80,15 +62,11 @@ provisioning:
     # - allowNonWorkspaceAccess=false: keeps agy scoped
     #   to the project workspace; prompts before
     #   accessing external paths.
-    # - enableTelemetry=true: required for OTLP export.
-    #   Without this, settings.json overrides the
-    #   GEMINI_CLI_TELEMETRY_ENABLED env var and
-    #   telemetry is silently disabled.
     # The host volume mount overlays this at runtime,
     # so users must also set these in their host-side
     # ~/.gemini/antigravity-cli/settings.json.
     - path: "/root/.gemini/antigravity-cli/settings.json"
-      content: '{"allowNonWorkspaceAccess": false, "enableTelemetry": true}'
+      content: '{"allowNonWorkspaceAccess": false}'
   verify: "agy --version"
   mounts:
     - host: "~/.gemini"

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -191,10 +191,31 @@ class TestUpdateTelemetry:
         assert changed is True
         assert tel["tokens"] == 350
 
+    def test_span_tokens_accumulate_across_calls(self, daemon):
+        """Multiple span-level token updates accumulate
+        via _span_* tracking keys (pi-otel per-request)."""
+        tel = self._base_tel()
+        # First LLM request
+        daemon._update_telemetry_from_attrs(
+            tel, {"gen_ai.usage.input_tokens": 100, "gen_ai.usage.output_tokens": 50}
+        )
+        assert tel["tokens"] == 150
+        assert tel["_span_input_tokens"] == 100
+        assert tel["_span_output_tokens"] == 50
+        # Second LLM request
+        daemon._update_telemetry_from_attrs(
+            tel, {"gen_ai.usage.input_tokens": 200, "gen_ai.usage.output_tokens": 80}
+        )
+        assert tel["tokens"] == 430  # 300 + 130
+        assert tel["_span_input_tokens"] == 300
+        assert tel["_span_output_tokens"] == 130
+
     def test_tokens_no_decrease(self, daemon):
         """Total tokens should never decrease."""
         tel = self._base_tel()
         tel["tokens"] = 500
+        # A small span update should not decrease the total
+        # even though _span_ accumulators start at 0.
         attrs = {"input_tokens": 10, "output_tokens": 5}
         daemon._update_telemetry_from_attrs(tel, attrs)
         # 15 < 500, so tokens should stay at 500
@@ -207,6 +228,19 @@ class TestUpdateTelemetry:
         attrs = {"input_tokens": 500, "output_tokens": 100}
         daemon._update_telemetry_from_attrs(tel, attrs)
         assert tel["context_tokens"] == 500
+
+    def test_cache_write_tokens_recognized(self, daemon):
+        """gen_ai.usage.cache_write_input_tokens from
+        pi-otel is handled as cache creation tokens."""
+        tel = self._base_tel()
+        attrs = {
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.output_tokens": 50,
+            "gen_ai.usage.cache_write_input_tokens": 30,
+        }
+        changed = daemon._update_telemetry_from_attrs(tel, attrs)
+        assert changed is True
+        assert tel["tokens"] == 180  # 100 + 50 + 30
 
     def test_activity_from_function_name(self, daemon):
         """Extracts current_activity from function_name attr."""
@@ -236,6 +270,28 @@ class TestUpdateTelemetry:
         tel = self._base_tel()
         changed = daemon._update_telemetry_from_attrs(tel, {})
         assert changed is False
+
+    def test_pi_cost_accumulates(self, daemon):
+        """pi.cost.usd from pi-otel is per-request and
+        must accumulate across multiple spans."""
+        tel = self._base_tel()
+        tel["cost_usd"] = 0.0
+        # First request costs $0.05
+        daemon._update_telemetry_from_attrs(tel, {"pi.cost.usd": 0.05})
+        assert tel["cost_usd"] == pytest.approx(0.05)
+        # Second request costs $0.03
+        daemon._update_telemetry_from_attrs(tel, {"pi.cost.usd": 0.03})
+        assert tel["cost_usd"] == pytest.approx(0.08)
+        # Third request costs $0.12
+        daemon._update_telemetry_from_attrs(tel, {"pi.cost.usd": 0.12})
+        assert tel["cost_usd"] == pytest.approx(0.20)
+
+    def test_pi_cost_zero_ignored(self, daemon):
+        """Zero-value pi.cost.usd is ignored."""
+        tel = self._base_tel()
+        tel["cost_usd"] = 0.10
+        daemon._update_telemetry_from_attrs(tel, {"pi.cost.usd": 0.0})
+        assert tel["cost_usd"] == pytest.approx(0.10)
 
 
 # ── D. _resolve_agent_id ─────────────────────────────────────
@@ -351,6 +407,54 @@ class TestResolveAgentId:
         }
         result = daemon._resolve_agent_id({"service.name": "pi-abc12345"})
         assert result == "pi-abc12345"
+
+    def test_agy_fallback_gemini_resource_attrs(self, daemon):
+        """Antigravity (agy) agents are matched when OTLP
+        resource attributes contain 'gemini' — agy shares
+        Gemini CLI's telemetry namespace."""
+        daemon.agents["agy-1"] = {
+            "tool": "agy",
+            "last_output_time": 1.0,
+        }
+        result = daemon._resolve_agent_id({"service.name": "gemini-cli"})
+        assert result == "agy-1"
+
+    def test_agy_direct_match_antigravity(self, daemon):
+        """Antigravity detected via 'antigravity' in
+        service.name."""
+        daemon.agents["agy-2"] = {
+            "tool": "agy",
+            "last_output_time": 1.0,
+        }
+        result = daemon._resolve_agent_id({"service.name": "antigravity-cli"})
+        assert result == "agy-2"
+
+    def test_gemini_hint_matches_both_gemini_and_agy(self, daemon):
+        """When both gemini and agy agents are running,
+        a 'gemini' hint in resource attrs matches both
+        as candidates and picks the most recent."""
+        daemon.agents["g-1"] = {
+            "tool": "gemini",
+            "last_output_time": 1.0,
+        }
+        daemon.agents["agy-1"] = {
+            "tool": "agy",
+            "last_output_time": 99.0,
+        }
+        result = daemon._resolve_agent_id({"service.name": "gemini-cli"})
+        assert result == "agy-1"  # most recent
+
+    def test_agy_hint_does_not_match_gemini(self, daemon):
+        """An explicit 'agy' hint only matches agy agents,
+        not gemini agents."""
+        daemon.agents["g-1"] = {
+            "tool": "gemini",
+            "last_output_time": 1.0,
+        }
+        # 'agy' in resource vals but no agy agent
+        result = daemon._resolve_agent_id({"service.name": "unknown", "sdk": "agy-sdk"})
+        # Falls back to single-agent last resort
+        assert result == "g-1"
 
 
 # ── E. get_git_info ──────────────────────────────────────────

--- a/frontend/src/components/dashboard/__tests__/utils.test.ts
+++ b/frontend/src/components/dashboard/__tests__/utils.test.ts
@@ -29,20 +29,24 @@ describe('getContextWindow', () => {
     expect(getContextWindow('claude-opus-4-20250514')).toBe(200000);
   });
 
-  it('returns 200k for claude-opus-4-6 without suffix', () => {
-    expect(getContextWindow('claude-opus-4-6')).toBe(200000);
+  it('returns 1M for claude-opus-4-6 (native 1M context)', () => {
+    expect(getContextWindow('claude-opus-4-6')).toBe(1000000);
+  });
+
+  it('returns 1M for claude-sonnet-4-6 (native 1M context)', () => {
+    expect(getContextWindow('claude-sonnet-4-6')).toBe(1000000);
   });
 
   it('returns 200k for claude-haiku-4', () => {
     expect(getContextWindow('claude-haiku-4-5')).toBe(200000);
   });
 
-  it('returns 1M when model has [1m] suffix', () => {
-    expect(getContextWindow('claude-opus-4-6[1m]')).toBe(1000000);
+  it('returns 1M when older model has [1m] suffix', () => {
+    expect(getContextWindow('claude-opus-4-5[1m]')).toBe(1000000);
   });
 
-  it('returns 1M for sonnet with [1m] suffix', () => {
-    expect(getContextWindow('claude-sonnet-4-6[1m]')).toBe(1000000);
+  it('returns 1M for sonnet 4-5 with [1m] suffix', () => {
+    expect(getContextWindow('claude-sonnet-4-5[1m]')).toBe(1000000);
   });
 
   it('returns 1048576 for gemini-2.5-pro model', () => {

--- a/frontend/src/components/dashboard/utils.ts
+++ b/frontend/src/components/dashboard/utils.ts
@@ -22,17 +22,22 @@ export const CONTEXT_TIERS = [
  * at the first hit, so more-specific keys must precede
  * less-specific ones within each model family.
  *
- * Claude models with a `[1m]` suffix (e.g.
- * "claude-opus-4-6[1m]") use 1M context; without the
- * suffix they default to 200k. The suffix is parsed in
+ * Claude models 4-6 and newer have 1M context natively.
+ * Older models (4-5 and below) default to 200k, with 1M
+ * available via a `[1m]` suffix (e.g.
+ * "claude-opus-4-5[1m]"). The suffix is parsed in
  * `getContextWindow()` before consulting this map.
  *
- * Last verified: 2026-05-28
+ * Last verified: 2026-07-31
  */
 export const CONTEXT_WINDOWS: Record<string, number> = {
-  // Claude — all default to 200k; 1M via [1m] suffix
-  'claude-opus-4-6': 200000,
-  'claude-sonnet-4-6': 200000,
+  // Claude — 4-6+ have native 1M context
+  'claude-fable-5': 1000000,
+  'claude-opus-4-8': 1000000,
+  'claude-opus-4-7': 1000000,
+  'claude-opus-4-6': 1000000,
+  'claude-sonnet-4-6': 1000000,
+  // Claude — 4-5 and older default to 200k; 1M via [1m] suffix
   'claude-opus-4-5': 200000,
   'claude-opus-4-1': 200000,
   'claude-opus-4': 200000,


### PR DESCRIPTION
## Summary

Fixes telemetry token, cost, and model reporting for Pi and Antigravity agent sessions. Resolves #90.

## Changes

### 1. Pi span-level token/cost accumulation (`host_daemon.py`)

pi-otel puts **per-request** token counts and cost on each `pi.llm_request` span. The daemon was using `max()` logic which only kept the largest single request value. Fixed by accumulating via `_span_*` tracking keys:

- `_span_input_tokens` / `_span_output_tokens` / `_span_cache_tokens` — sum across spans
- `_span_cost_usd` — accumulates `pi.cost.usd` per-request values
- Metric-based path (cumulative histograms) still uses `max()` correctly and supersedes span values when active

Also adds `gen_ai.usage.cache_write_input_tokens` handling for pi-otel's cache write attribute.

### 2. Antigravity agent ID resolution (`host_daemon.py`)

`_resolve_agent_id()` mapped `"gemini"` in OTLP resource attributes to `tool_hint="gemini"`, but Antigravity agents have `tool="agy"`, so the candidate filter silently failed. Fixed by:
- Adding explicit `"antigravity"`/`"agy"` detection before the gemini check
- Expanding gemini hint matching to include both `{"gemini", "agy"}` as candidates

### 3. OTEL env var leak between agents (`host_daemon.py`)

The daemon's `os.environ` inherits stale `OTEL_SERVICE_NAME` from previously-spawned agent sessions (via tmux). Agents whose profiles don't explicitly set this var (like agy) inherited incorrect values, causing OTLP routing mismatches. Fixed by stripping all `OTEL_*` and `PI_OTEL*` vars from the subprocess env before injecting profile-specific values.

### 4. Antigravity OTLP telemetry config removal (`agy.yaml`)

Binary analysis of agy v1.0.15 confirmed it does **not** support OTLP export. It sends telemetry only to Google's internal BusinessAI gRPC endpoints. The `GEMINI_TELEMETRY_*` env vars and `telemetry` metric mappings inherited from the Gemini CLI profile were completely inert. Removed all dead config and documented the limitation. OTLP support tracked upstream: [google-antigravity/antigravity-cli#366](https://github.com/google-antigravity/antigravity-cli/issues/366).

### 5. Context window sizes for Claude 4-6+ models (`utils.ts`)

Claude opus-4-6, sonnet-4-6, opus-4-7, opus-4-8, and fable-5 have native 1M context windows. The table previously listed these as 200k, causing incorrect context bar scaling. Verified against pi-ai's built-in model catalog.

## Testing

- 91 backend unit tests passing (7 new tests for token accumulation, cost accumulation, cache write tokens, and agy agent ID resolution)
- 61 frontend tests passing (updated context window tests)
- Pi telemetry validated end-to-end: OTLP traces with token/cost/model data confirmed flowing to dashboard after upstream pi-vertex fix ([ssweens/pi-packages#7](https://github.com/ssweens/pi-packages/pull/7))

## Upstream Issues Filed

- [ssweens/pi-packages#6](https://github.com/ssweens/pi-packages/issues/6) + [PR #7](https://github.com/ssweens/pi-packages/pull/7) — pi-vertex missing `onPayload`/`onResponse` callbacks (root cause of missing Pi telemetry)
- [NikiforovAll/pi-otel#10](https://github.com/NikiforovAll/pi-otel/issues/10) — `message_end` fallback for custom providers
- [earendil-works/pi#7372](https://github.com/earendil-works/pi/issues/7372) — `streamSimple` JSDoc gap
- [google-antigravity/antigravity-cli#366](https://github.com/google-antigravity/antigravity-cli/issues/366) — OTLP support request (existing)