### PR TITLE
security: fix auth bypass, command injection, and insecure defaults (#111, #112, #113)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -74,10 +74,25 @@ def _is_dev_build(version: str) -> bool:
 
 fastapi_app = FastAPI(title="AI Coding Agent Dashboard API")
 
-# Add Session Middleware for OIDC
-fastapi_app.add_middleware(
-    SessionMiddleware, secret_key=os.getenv("SECRET_KEY", "super-secret-default-key")
-)
+# Add Session Middleware for OIDC.
+# SECRET_KEY is required when authentication is enabled.
+# In BYPASS_AUTH mode a placeholder is acceptable since
+# sessions are not used for access control.
+_bypass_auth = os.getenv("BYPASS_AUTH", "false").lower() == "true"
+_secret_key = os.getenv("SECRET_KEY", "")
+if not _secret_key and not _bypass_auth:
+    import secrets as _secrets
+
+    _secret_key = _secrets.token_hex(32)
+    print(
+        "WARNING: SECRET_KEY not set — generated an ephemeral key. "
+        "Sessions will not survive restarts. Set SECRET_KEY in the "
+        "environment for production use."
+    )
+elif not _secret_key:
+    _secret_key = "bypass-auth-placeholder"
+
+fastapi_app.add_middleware(SessionMiddleware, secret_key=_secret_key)
 
 # Add CORS Middleware
 # In lab environments (BYPASS_AUTH=true), we allow any HTTP/HTTPS origin.
@@ -89,7 +104,7 @@ allowed_origins = [
     origin.strip() for origin in allowed_origins_env.split(",") if origin.strip()
 ]
 
-if os.getenv("BYPASS_AUTH", "false").lower() == "true":
+if _bypass_auth:
     fastapi_app.add_middleware(
         CORSMiddleware,
         allow_origins=allowed_origins,

--- a/backend/app/socket.py
+++ b/backend/app/socket.py
@@ -4,9 +4,14 @@ Manages real-time communication between the frontend UI, the
 backend hub, and remote host daemons over the /terminal namespace.
 """
 
+import json
+import os
+from base64 import b64decode
 from datetime import datetime, timezone
+from http.cookies import SimpleCookie
 
 import socketio
+from itsdangerous import TimestampSigner, BadSignature
 
 from . import database, models
 
@@ -14,11 +19,50 @@ from . import database, models
 sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
 
 
+def _validate_session_cookie(environ):
+    """Validate the Starlette session cookie from the ASGI scope.
+
+    Parses the Cookie header, extracts the 'session' cookie,
+    and verifies its signature using the same SECRET_KEY that
+    SessionMiddleware uses. Returns the decoded session dict
+    on success, or None on failure.
+    """
+    secret_key = os.getenv("SECRET_KEY", "")
+    if not secret_key:
+        return None
+
+    headers = dict(environ.get("asgi.scope", {}).get("headers", []))
+    cookie_header = None
+    for k, v in headers.items():
+        if k == b"cookie":
+            cookie_header = v.decode("utf-8")
+            break
+    if not cookie_header:
+        return None
+
+    cookies = SimpleCookie()
+    cookies.load(cookie_header)
+    session_morsel = cookies.get("session")
+    if not session_morsel:
+        return None
+
+    signer = TimestampSigner(secret_key)
+    try:
+        data = signer.unsign(session_morsel.value.encode("utf-8"))
+        return json.loads(b64decode(data))
+    except (BadSignature, Exception):
+        return None
+
+
 @sio.on("connect", namespace="/terminal")
 async def connect(sid, environ, auth):
     """
     Handles new Socket.IO connections on the /terminal namespace.
     Identifies if the connection is from a Host Daemon or a UI Client.
+
+    Host daemons authenticate via X-Host-Token header or auth.token.
+    UI clients are validated against the OIDC session cookie when
+    authentication is enabled (BYPASS_AUTH is not set).
     """
     headers = dict(environ.get("asgi.scope", {}).get("headers", []))
     headers_str = {
@@ -28,7 +72,12 @@ async def connect(sid, environ, auth):
     host_token = headers_str.get("x-host-token") or (auth and auth.get("token"))
 
     if not host_token:
-        # UI client connected
+        # UI client — enforce auth unless bypassed
+        bypass = os.getenv("BYPASS_AUTH", "false").lower() == "true"
+        if not bypass:
+            session = _validate_session_cookie(environ)
+            if not session or "user" not in session:
+                return False
         return True
 
     db = next(database.get_db())

--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,14 @@ services:
       - dashboard_data:/app/data
     environment:
       - DATABASE_URL=sqlite:////app/data/agent_dashboard.db
-      - BYPASS_AUTH=true
+      # Authentication is enforced by default. To disable
+      # for local development, uncomment the next line:
+      # - BYPASS_AUTH=true
+      # Required when auth is enabled (BYPASS_AUTH unset):
+      # - SECRET_KEY=<generate-a-random-secret>
+      # - OIDC_CLIENT_ID=<your-oidc-client-id>
+      # - OIDC_CLIENT_SECRET=<your-oidc-client-secret>
+      # - OIDC_DISCOVERY_URL=<your-oidc-discovery-url>
     restart: unless-stopped
 
   frontend:

--- a/tui/app.py
+++ b/tui/app.py
@@ -122,28 +122,37 @@ class AgentDashboardApp(App):
             parts.append(branch)
         window_name = ":".join(parts)
 
-        # Build the terminal client command. Ensure the
-        # tmux subprocess uses the same working directory,
-        # venv, and PYTHONPATH as the TUI.
+        # Build the terminal client command as an
+        # argument list to avoid shell injection via
+        # server-supplied values (agent_id, base_url).
         cwd = os.getcwd()
         venv = os.environ.get("VIRTUAL_ENV", "")
-        activate = f"source {venv}/bin/activate && " if venv else ""
-        client_cmd = (
-            f"cd {cwd} && {activate}"
-            f"PYTHONPATH={cwd}:$PYTHONPATH "
-            f"{sys.executable} -m tui.terminal_client "
-            f"{agent_id} --url {self.base_url}"
-        )
+        env = os.environ.copy()
+        env["PYTHONPATH"] = f"{cwd}:{env.get('PYTHONPATH', '')}"
+        if venv:
+            venv_bin = os.path.join(venv, "bin")
+            env["PATH"] = f"{venv_bin}:{env.get('PATH', '')}"
+            env["VIRTUAL_ENV"] = venv
+        client_argv = [
+            sys.executable,
+            "-m",
+            "tui.terminal_client",
+            agent_id,
+            "--url",
+            self.base_url,
+        ]
 
         if self._in_tmux:
-            # Open a new tmux window with the terminal client
+            # Open a new tmux window with the terminal
+            # client. tmux new-window accepts a command
+            # with arguments as separate tokens.
             subprocess.run(
                 [
                     "tmux",
                     "new-window",
                     "-n",
                     window_name,
-                    client_cmd,
+                    *client_argv,
                 ],
                 check=False,
             )
@@ -152,7 +161,7 @@ class AgentDashboardApp(App):
             # Not in tmux — exit the TUI and run the
             # terminal client directly. The user can
             # relaunch the TUI after disconnecting.
-            self._attach_cmd = client_cmd
+            self._attach_cmd = (client_argv, env, cwd)
             self.exit()
 
     async def on_unmount(self) -> None:
@@ -176,9 +185,11 @@ def main():
     # If the user pressed attach without tmux, the TUI
     # exits and we run the terminal client directly.
     if app._attach_cmd:  # pylint: disable=protected-access
+        argv, env, cwd = app._attach_cmd  # pylint: disable=protected-access
         subprocess.run(
-            app._attach_cmd,  # pylint: disable=protected-access
-            shell=True,
+            argv,
+            env=env,
+            cwd=cwd,
             check=False,
         )
 


### PR DESCRIPTION
## Summary

Addresses three security issues filed on 2026-07-30.

### Commit 1: Remove hardcoded SECRET_KEY and BYPASS_AUTH defaults (#112)

- **compose.yml**: `BYPASS_AUTH=true` was the default — auth was disabled out of the box. Removed; auth is now enforced by default with comments showing how to configure OIDC or re-enable BYPASS_AUTH for dev.
- **backend/app/main.py**: Removed hardcoded `SECRET_KEY` fallback (`"super-secret-default-key"`). When SECRET_KEY is not set and auth is enabled, an ephemeral key is generated with a startup warning. In BYPASS_AUTH mode, a harmless placeholder is used.

### Commit 2: Eliminate shell injection in TUI attach command (#113)

- **tui/app.py**: The TUI built a shell command string by interpolating `agent_id` and `base_url` (server-supplied values) into an f-string, then executed it with `shell=True`. Replaced with an explicit argument list (`shell=False`). Environment setup (PYTHONPATH, VIRTUAL_ENV) is handled via the env dict instead of shell source/export commands. `_attach_cmd` now carries `(argv, env, cwd)` instead of a shell string.

### Commit 3: Authenticate Socket.IO UI connections (#111)

- **backend/app/socket.py**: The `/terminal` namespace accepted all connections without a host token as UI clients with no authentication. Added session cookie validation on connect: when `BYPASS_AUTH` is not enabled, the Starlette session cookie is verified using the same `SECRET_KEY` and `itsdangerous.TimestampSigner` that `SessionMiddleware` uses. Connections without a valid OIDC session are rejected. BYPASS_AUTH mode preserves the existing dev workflow.

## Testing

- 111 backend tests passing (5 E2E errors are pre-existing — missing uvicorn in stale .venv)
- 61 frontend tests passing
- 91 daemon tests passing

## Breaking Changes

Users who relied on the default `BYPASS_AUTH=true` in compose.yml will need to either:
1. Set `BYPASS_AUTH=true` explicitly in their environment, or
2. Configure OIDC credentials and a `SECRET_KEY`

Fixes #111, #112, #113