### PR TITLE
docs: pre-release documentation review and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,13 @@ Then rebuild: `podman-compose build --no-cache && podman-compose up -d`
 > sudo firewall-cmd --reload
 > ```
 
-> [!NOTE]
-> For internal or private lab networks, keep `BYPASS_AUTH=true`
-> in `compose.yml` to skip OIDC authentication.
+> [!IMPORTANT]
+> **Authentication is enforced by default.** `BYPASS_AUTH` is
+> commented out in `compose.yml`. For local development or
+> private lab networks without OIDC, uncomment it or add
+> `BYPASS_AUTH=true` to the backend environment in
+> `compose.yml`. For production, configure OIDC — see the
+> [Host Daemon Reference](docs/host-daemon.md).
 
 ### 3. Register a Host
 
@@ -457,7 +461,7 @@ each have their own isolated worktree with a separate branch.
 | Terminal popup shows nginx 404 | Fedora base image update added a conflicting default server block | Rebuild frontend container (fixed in v0.4.0) |
 | `netavark: setns: Operation not permitted` when running podman inside daemon | Nested container networking blocked | Daemon Containerfile configures `slirp4netns` automatically |
 | Agent card reappears after clicking Stop | Terminal popup auto-reconnects the session | Close the terminal window before stopping, or upgrade to v0.3.1+ |
-| `1;2c` appears in Gemini input | Terminal DA response leaks into stdin | Upgrade to v0.3.1+ (filtered automatically) |
+| `1;2c` appears in agent input | Terminal DA response leaks into stdin | Upgrade to v0.3.1+ (filtered automatically) |
 | Token counts grow unrealistically | OTLP cumulative counters were double-counted | Upgrade to v0.3.1+ |
 
 ## Similar Tools
@@ -472,7 +476,7 @@ strengths and trade-offs:
   - A web-based platform that provides multi-host orchestration and remote pseudo-terminal (PTY) access to AI agent sessions with live OpenTelemetry metrics. Supports optional git worktree isolation for running multiple agents on the same repository, real-time cost tracking, and companion session chaining.
   - **Ideal for:** Remote, web-based interaction with isolated AI agent sessions across multiple host machines via full PTY emulation.
   - **Not ideal for:** Users who prefer to work exclusively within a local, native terminal multiplexer.
-  - **Restrictions:** Only supports Gemini CLI, Claude Code, and Bash sessions. Does not orchestrate GUI-based agents, arbitrary scripts, or non-interactive processes.
+  - **Restrictions:** Only supports Claude Code, Pi, Antigravity, and Bash sessions. Does not orchestrate GUI-based agents, arbitrary scripts, or non-interactive processes.
 
 - **[Agent Commander](https://github.com/cvsloane/agent-commander)**
   - A mission-control dashboard and tmux-first manager for AI agent sessions across multiple hosts. Built with Next.js, Fastify, and a Go-based agent daemon. Features approval queues for agent governance, scoped memory systems, and scheduling with runtime reuse.
@@ -529,7 +533,7 @@ cd frontend && npm install && cd ..
 
 > [!IMPORTANT]
 > **AI agent development:** If you are using an AI coding agent
-> (Claude Code, Gemini CLI, etc.) to develop on this project,
+> (Claude Code, Pi, etc.) to develop on this project,
 > always install the pre-commit hook first. AI agents can
 > introduce formatting, linting, and type errors that slip past
 > review. The hook catches these automatically on every commit.

--- a/agent/README.md
+++ b/agent/README.md
@@ -10,7 +10,8 @@ The Host Daemon runs on remote development machines and manages AI agent session
 
 The daemon uses YAML/JSON profile files to define how each
 agent tool is spawned, detected, and monitored. Bundled
-profiles for Claude, Gemini, and Bash are in `agent/profiles/`.
+profiles for Claude, Pi, Antigravity, and Bash are in
+`agent/profiles/`.
 Custom profiles can be added by dropping a YAML file into the
 same directory. See [Agent Profiles](../docs/agent-profiles.md)
 for the full schema and examples.
@@ -21,8 +22,9 @@ The container image bundles the following tools so spawned agents have everythin
 
 | Tool | Purpose |
 |------|---------|
-| **Gemini CLI** (`@google/gemini-cli`) | Google Gemini AI coding agent |
 | **Claude Code** (`@anthropic-ai/claude-code`) | Anthropic Claude AI coding agent |
+| **Pi** (`@earendil-works/pi-coding-agent`) | Pi coding agent — provider-agnostic |
+| **Antigravity CLI** (`agy`) | Google Antigravity AI coding agent |
 | **Google Cloud CLI** (`gcloud`) | GCP authentication for Claude Code via Vertex AI |
 | **GitHub CLI** (`gh`) | GitHub interaction (PRs, issues, etc.) |
 | **GitLab CLI** (`glab`) | GitLab interaction (MRs, issues, etc.) |

--- a/agent/pi-defaults/README.md
+++ b/agent/pi-defaults/README.md
@@ -141,3 +141,14 @@ matching Claude Code's native sub-agent behavior.
 
 No manual patching is needed — the env var is injected
 automatically by the daemon at spawn time.
+
+## Known Limitations
+
+### pi-otel telemetry
+
+pi-otel telemetry requires the upstream pi-vertex fix
+([ssweens/pi-packages#7](https://github.com/ssweens/pi-packages/issues/7))
+for `onPayload`/`onResponse` callbacks. Without this fix,
+token usage, cost, and model data are not reported to the
+dashboard when using Pi with the pi-vertex provider.
+Telemetry works correctly with other Pi providers.

--- a/agent/profiles/TEMPLATE.yaml.example
+++ b/agent/profiles/TEMPLATE.yaml.example
@@ -145,6 +145,16 @@ auth:
 #   - "Do you want to proceed"
 #   - "Allow .+ to run"
 
+# ── Spawn Settings ──────────────────────────────────
+# Dict of file paths to JSON key/value pairs. At spawn
+# time, missing keys are added to the target file without
+# overwriting existing values. Used to ensure required
+# settings are present for fresh installs.
+
+# spawn_settings:
+#   "~/.myagent/settings.json":
+#     allowNonWorkspaceAccess: false
+
 # ── Provisioning ─────────────────────────────────────
 # Build-time metadata used by generate_containerfile.py
 # to produce the Containerfile, and as documentation for

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -18,6 +18,11 @@ Four profiles are included out of the box:
 | Bash | `agent/profiles/bash.yaml` | Bash shell with PROMPT_COMMAND sidecar telemetry |
 | Gemini | `agent/profiles/archive/gemini.yaml` | Gemini CLI — **retired** from default install (see below) |
 
+Retired profiles are moved to `agent/profiles/archive/` where
+they remain available for reference but are not loaded by the
+daemon. To restore an archived profile, copy it back to
+`agent/profiles/` or use a `.local.yaml` override.
+
 ## Creating a Custom Profile
 
 To add support for a new agent tool, create a YAML or JSON
@@ -110,6 +115,7 @@ and as documentation for manual container setup.
 | `provisioning.verify` | string | no | `null` | Command to verify the installation succeeded (e.g., `"claude --version"`). Run as a `RUN` step in the Containerfile. |
 | `provisioning.mounts` | list | no | `[]` | Host volume mounts. Each entry has `host` (string, `~` expanded), `container` (string), and `mode` (`"rw"` or `"ro"`). |
 | `provisioning.passthrough_env` | list | no | `[]` | Environment variables to pass from the host to the container at runtime (via `podman run -e` or quadlet `Environment=`). Distinct from `env` which the daemon injects at agent spawn time. |
+| `spawn_settings` | map | no | `{}` | Dict of file paths to JSON key/value pairs. At spawn time, missing keys are added to the target file without overwriting existing values. Used to ensure required settings (e.g. `allowNonWorkspaceAccess`) are present. |
 
 ### Full Example
 
@@ -284,7 +290,7 @@ automatically** from the `commands` configuration — no
 separate flag is needed:
 
 - **Supports resume**: `commands.resume` is defined AND
-  differs from `commands.new` (e.g. Claude, Gemini).
+  differs from `commands.new` (e.g. Claude, Antigravity).
 - **No resume**: `commands.resume` is empty, undefined, or
   identical to `commands.new` (e.g. Bash where both are
   `["bash"]`).

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -84,7 +84,8 @@ podman run -d --name host-daemon --network=host \
 | `PROJECTS_ROOT` | Root directory (or colon-separated list) for project scanning | `/git` |
 | `OTLP_PORT` | OTLP telemetry receiver port | `4318` |
 | `PROJECTS_DEPTH` | Max scan depth below each `PROJECTS_ROOT` entry | `6` |
-| `GEMINI_API_KEY` | API key for Gemini CLI | — |
+| `OTLP_DEBUG` | Set to any value to log raw OTLP payloads for troubleshooting | — |
+| `GEMINI_API_KEY` | API key for Gemini CLI (if installed) | — |
 | `CLAUDE_CODE_USE_VERTEX` | Set to `1` to use Vertex AI for Claude | — |
 | `CLOUD_ML_REGION` | GCP region (e.g., `us-east5`) | — |
 | `ANTHROPIC_VERTEX_PROJECT_ID` | GCP project ID for Vertex AI | — |
@@ -98,7 +99,7 @@ podman run -d --name host-daemon --network=host \
 | `/path/to/your/git` | `/git` | rw | Project source code |
 | `~/.ssh` | `/root/.ssh` | ro | SSH keys for git operations |
 | `~/.gitconfig` | `/root/.gitconfig` | ro | Git configuration |
-| `~/.gemini/` | `/root/.gemini` | rw | Gemini CLI / Antigravity CLI settings |
+| `~/.gemini/` | `/root/.gemini` | rw | Antigravity CLI settings (also used by Gemini CLI if installed) |
 | `~/.claude/` | `/root/.claude` | rw | Claude Code settings |
 | `~/.claude.json` | `/root/.claude.json` | ro | Claude Code MCP server config |
 | `~/.pi/` | `/root/.pi` | rw | Pi coding agent settings and extensions |
@@ -185,7 +186,7 @@ services:
 | Setting | Description |
 |---------|-------------|
 | `VITE_API_URL` | Backend URL for remote access (build arg via `.env`) |
-| `BYPASS_AUTH` | Set to `true` to skip OIDC auth (default in compose) |
+| `BYPASS_AUTH` | Set to `true` to skip OIDC auth (commented out by default) |
 | `DATABASE_URL` | SQLite path inside the backend container |
 | `dashboard_data` | Named volume for database persistence |
 
@@ -237,8 +238,9 @@ The daemon container bundles the following tools:
 
 | Tool | Purpose |
 |------|---------|
-| **Gemini CLI** (`@google/gemini-cli`) | Google Gemini AI coding agent |
 | **Claude Code** (`@anthropic-ai/claude-code`) | Anthropic Claude AI coding agent |
+| **Pi** (`@earendil-works/pi-coding-agent`) | Pi coding agent — provider-agnostic |
+| **Antigravity CLI** (`agy`) | Google Antigravity AI coding agent |
 | **Google Cloud CLI** (`gcloud`) | GCP authentication for Claude via Vertex AI |
 | **GitHub CLI** (`gh`) | GitHub interaction (PRs, issues, etc.) |
 | **GitLab CLI** (`glab`) | GitLab interaction (MRs, issues, etc.) |


### PR DESCRIPTION
Documentation review and updates ahead of the next release.

**Changes:**
- Remove stale Gemini CLI references from README, agent/README, and host-daemon docs
- Update default agent lists to Claude, Pi, Antigravity, Bash throughout
- Document BYPASS_AUTH default change (auth enforced by default)
- Add `spawn_settings` to profile field reference table
- Document `archive/` directory for retired profiles
- Add `OTLP_DEBUG` troubleshooting env var to host daemon docs
- Note pi-vertex `onPayload`/`onResponse` limitation in Pi defaults README
- Add `spawn_settings` example to TEMPLATE.yaml.example
- Fix Pi package name (`@earendil-works/pi-coding-agent`) in host-daemon.md
- Update `.gemini` volume mount description (Antigravity, not Gemini)
- Fix BYPASS_AUTH description in host-daemon compose reference