### PR TITLE
fix: enable bracketed paste mode for multi-line paste support

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -241,6 +241,15 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
     fitAddon.fit();
     term.focus();
 
+    // Enable bracketed paste mode so multi-line pastes
+    // are wrapped in ESC[200~ / ESC[201~ sequences.
+    // Applications (e.g. Pi) request this via ESC[?2004h,
+    // but tmux intercepts that sequence and doesn't
+    // forward it to the daemon's PTY. Without this,
+    // each pasted newline is treated as Enter and
+    // submitted as a separate prompt.
+    term.write('\x1b[?2004h');
+
     // --- Scroll position tracking ---
     // Track whether the viewport is scrolled to the bottom
     // so we can restore position after fitAddon.fit()


### PR DESCRIPTION
Multi-line pastes in the dashboard terminal are split into separate prompts because xterm.js doesn't have bracketed paste mode enabled.

**Root cause:** Applications like Pi enable bracketed paste via `ESC[?2004h`, but tmux intercepts this sequence and doesn't forward it through the PTY. xterm.js never sees the enable command, so when the user pastes text containing newlines, each line is sent as a separate keystroke — each newline becomes Enter.

**Fix:** Write `ESC[?2004h` directly to xterm.js on terminal initialization. This enables bracketed paste regardless of whether the inner application's request survives the tmux layer. When the user pastes, xterm.js wraps the text in `ESC[200~` / `ESC[201~` sequences, and the application receives the entire paste as one input.