### PR TITLE
feat: add OpenCode agent profile

### DIFF
--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -637,6 +637,31 @@ class HostDaemon:
 
         return branch, project, remote_url
 
+    @staticmethod
+    def _merge_missing_keys(target, defaults):
+        """Deep-merge default keys into target dict.
+
+        Only adds keys that are missing in the target.
+        For nested dicts, recurses so that sub-keys can
+        be added without overwriting sibling keys.
+
+        Args:
+            target: Dict to update in place.
+            defaults: Dict of keys/values to add if missing.
+
+        Returns:
+            True if any key was added, False otherwise.
+        """
+        changed = False
+        for key, value in defaults.items():
+            if key not in target:
+                target[key] = value
+                changed = True
+            elif isinstance(value, dict) and isinstance(target[key], dict):
+                if HostDaemon._merge_missing_keys(target[key], value):
+                    changed = True
+        return changed
+
     def _detect_mcp_servers(self, project_dir, tool):
         """Detects MCP servers configured for the given tool.
 
@@ -883,11 +908,7 @@ class HostDaemon:
                     if os.path.exists(filepath):
                         with open(filepath, "r", encoding="utf-8") as f:
                             existing = json.load(f)
-                    changed = False
-                    for key, value in required_keys.items():
-                        if key not in existing:
-                            existing[key] = value
-                            changed = True
+                    changed = self._merge_missing_keys(existing, required_keys)
                     if changed:
                         os.makedirs(
                             os.path.dirname(filepath),
@@ -1492,6 +1513,8 @@ class HostDaemon:
             tool_hint = "claude"
         elif "pi" == svc.lower() or "pi-otel" in all_vals:
             tool_hint = "pi"
+        elif "opencode" in svc.lower() or "opencode" in all_vals:
+            tool_hint = "opencode"
 
         if tool_hint:
             # Build candidate list.  When the hint is

--- a/agent/profiles/opencode.yaml
+++ b/agent/profiles/opencode.yaml
@@ -1,0 +1,85 @@
+# OpenCode agent profile (anomalyco/opencode)
+# Open-source AI coding agent with multi-provider
+# support. TypeScript/Node.js, distributed as the
+# opencode-ai npm package.
+#
+# OTLP telemetry: Partial. Traces and logs are
+# exported when OTEL_EXPORTER_OTLP_ENDPOINT is set.
+# Metrics (token usage, cost) are NOT exported.
+# OTEL_SERVICE_NAME is currently ignored (hardcoded
+# to "opencode") — multi-instance tracking relies
+# on the daemon's fallback agent ID resolution.
+# Tracked upstream:
+#   - Service name: anomalyco/opencode#25839
+name: opencode
+display_name: OpenCode
+color: amber
+binary: opencode
+
+commands:
+  new: ["opencode"]
+  resume: ["bash", "-c", "opencode --continue || opencode"]
+
+# OTEL_EXPORTER_OTLP_ENDPOINT is the master switch
+# for OpenCode's OTLP export. Setting it enables
+# trace and log export to the daemon's receiver.
+# OTEL_EXPORTER_OTLP_PROTOCOL is not needed —
+# OpenCode uses http/json by default.
+env:
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/json"
+
+# No auth gate — OpenCode supports many providers
+# (Anthropic, OpenAI, Gemini, Copilot, Bedrock,
+# etc.) with their own API key env vars. Binary
+# presence is sufficient. If no provider is
+# configured, OpenCode prompts at startup.
+
+# Spawn-time settings — ensure experimental OTLP
+# span generation is enabled for richer traces.
+spawn_settings:
+  ~/.opencode/config.json:
+    experimental:
+      openTelemetry: true
+
+mcp:
+  user_files:
+    - ~/.opencode/config.json
+
+# No telemetry metrics section — OpenCode does not
+# export OTLP metrics (token usage, cost, activity).
+# Traces provide model name and current activity
+# via span attributes, which the daemon extracts
+# in _update_telemetry_from_attrs().
+
+permission_patterns:
+  - "Allow"
+  - "Grant"
+  - "approve"
+
+# Build-time provisioning metadata
+provisioning:
+  install:
+    npm:
+      - "opencode-ai"
+  config_files:
+    - path: "/root/.opencode"
+      mkdir: true
+    - path: "/root/.opencode/config.json"
+      content: '{"experimental": {"openTelemetry": true}}'
+  verify: "opencode --version"
+  mounts:
+    - host: "~/.opencode"
+      container: "/root/.opencode"
+      mode: rw
+  passthrough_env:
+    - ANTHROPIC_API_KEY
+    - OPENAI_API_KEY
+    - GEMINI_API_KEY
+    - GITHUB_TOKEN
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_REGION
+    - AZURE_OPENAI_API_KEY
+    - AZURE_OPENAI_BASE_URL
+    - XAI_API_KEY
+    - OPENROUTER_API_KEY

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -456,6 +456,16 @@ class TestResolveAgentId:
         # Falls back to single-agent last resort
         assert result == "g-1"
 
+    def test_opencode_fallback_service_name(self, daemon):
+        """OpenCode hardcodes service.name to 'opencode'.
+        The fallback matches it to opencode agents."""
+        daemon.agents["oc-1"] = {
+            "tool": "opencode",
+            "last_output_time": 1.0,
+        }
+        result = daemon._resolve_agent_id({"service.name": "opencode"})
+        assert result == "oc-1"
+
 
 # ── E. get_git_info ──────────────────────────────────────────
 
@@ -1075,6 +1085,57 @@ class TestLocalProfileOverrides:
 
 
 # ── I. Multi-Root Projects ─────────────────────────────
+
+
+# ── J. _merge_missing_keys ─────────────────────────────
+
+
+class TestMergeMissingKeys:
+    """Tests for _merge_missing_keys deep merge."""
+
+    def test_flat_keys_added(self, daemon):
+        """Missing flat keys are added."""
+        target = {"a": 1}
+        changed = daemon._merge_missing_keys(target, {"b": 2})
+        assert changed is True
+        assert target == {"a": 1, "b": 2}
+
+    def test_existing_keys_preserved(self, daemon):
+        """Existing keys are not overwritten."""
+        target = {"a": 1}
+        changed = daemon._merge_missing_keys(target, {"a": 99})
+        assert changed is False
+        assert target == {"a": 1}
+
+    def test_nested_keys_added(self, daemon):
+        """Missing nested keys are added without
+        overwriting sibling keys."""
+        target = {"experimental": {"existingKey": True}}
+        defaults = {"experimental": {"openTelemetry": True}}
+        changed = daemon._merge_missing_keys(target, defaults)
+        assert changed is True
+        assert target == {
+            "experimental": {
+                "existingKey": True,
+                "openTelemetry": True,
+            }
+        }
+
+    def test_nested_existing_preserved(self, daemon):
+        """Existing nested keys are not overwritten."""
+        target = {"experimental": {"openTelemetry": False}}
+        defaults = {"experimental": {"openTelemetry": True}}
+        changed = daemon._merge_missing_keys(target, defaults)
+        assert changed is False
+        assert target["experimental"]["openTelemetry"] is False
+
+    def test_new_nested_dict_added(self, daemon):
+        """Entirely missing nested dict is added."""
+        target = {}
+        defaults = {"experimental": {"openTelemetry": True}}
+        changed = daemon._merge_missing_keys(target, defaults)
+        assert changed is True
+        assert target == {"experimental": {"openTelemetry": True}}
 
 
 class TestMultiRoot:


### PR DESCRIPTION
## Summary

Adds [OpenCode](https://github.com/anomalyco/opencode) (formerly sst/opencode) as a supported agent in the dashboard.

## Profile Details

- **Install**: `opencode-ai` npm package
- **Resume**: `opencode --continue`
- **OTLP**: Traces and logs via `OTEL_EXPORTER_OTLP_ENDPOINT` (no metrics)
- **MCP**: Detected from `~/.opencode/config.json`
- **Permissions**: Tool approval prompts detected
- **Providers**: Anthropic, OpenAI, Gemini, Copilot, Bedrock, Groq, Azure, Vertex, OpenRouter, XAI

## Known Limitations

- **No OTLP metrics**: Token usage, cost, and activity counters are not exported. Dashboard cards show model and activity from span attributes but no token/cost data.
- **Hardcoded service.name**: OpenCode ignores `OTEL_SERVICE_NAME` and hardcodes it to `"opencode"` ([#25839](https://github.com/anomalyco/opencode/issues/25839)). Agent ID resolution falls back to tool-type matching. Multiple simultaneous OpenCode sessions may have telemetry routing issues.

## Code Changes

- `agent/profiles/opencode.yaml` — new profile
- `agent/host_daemon.py`:
  - Added `"opencode"` to `_resolve_agent_id()` fallback hints
  - Added `_merge_missing_keys()` for deep-merge of nested spawn_settings (OpenCode's config uses `{"experimental": {"openTelemetry": true}}`)
- `agent/tests/test_host_daemon.py` — 5 new tests (agent ID resolution + deep merge)

## Testing

95 unit tests passing.