### PR TITLE
docs: add OpenCode to documentation and agent lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Agent Dashboard</h1>
 
 <p align="center">
-A multi-host orchestration platform for AI coding agents — spawn, monitor, and interact with Claude Code, Pi, Antigravity, and Bash sessions across multiple machines from a single web dashboard.
+A multi-host orchestration platform for AI coding agents — spawn, monitor, and interact with Claude Code, Pi, Antigravity, OpenCode, and Bash sessions across multiple machines from a single web dashboard.
 </p>
 
 <p align="center">
@@ -28,8 +28,8 @@ AI coding agents. It remotely spawns, monitors, and provides
 interactive terminal access to AI coding agent sessions
 running across multiple development machines — all from a
 single web interface. Supports Claude Code, Pi, Antigravity
-(agy), and Bash out of the box, with new agents added via
-YAML profiles.
+(agy), OpenCode, and Bash out of the box, with new agents
+added via YAML profiles.
 
 > [!TIP]
 > **How it works:** Install the hub (backend + frontend) on any
@@ -253,6 +253,7 @@ podman run -d --name host-daemon --network=host \
   -v $HOME/.claude.json:/root/.claude.json:ro \
   -v $HOME/.gemini/:/root/.gemini \
   -v $HOME/.pi:/root/.pi \
+  -v $HOME/.opencode:/root/.opencode \
   localhost/agent-dashboard-daemon:latest
 ```
 
@@ -261,7 +262,7 @@ podman run -d --name host-daemon --network=host \
 > expect agent config directories to exist on the host.
 > If you haven't used these tools locally, create them first:
 > ```bash
-> mkdir -p ~/.claude ~/.gemini ~/.pi/agent
+> mkdir -p ~/.claude ~/.gemini ~/.pi/agent ~/.opencode
 > ```
 
 > [!TIP]
@@ -284,7 +285,7 @@ podman run -d --name host-daemon --network=host \
 1. Open `http://your-server-ip:8080`
 2. Your registered hosts appear on the dashboard
 3. Click **Spawn Claude**, **Spawn Pi**, **Spawn Antigravity**,
-   or **Spawn Bash**
+   **Spawn OpenCode**, or **Spawn Bash**
 4. Select a project directory from the dropdown
 5. Click a running session to attach in a terminal popup
 6. Delete retired hosts via the trash icon
@@ -476,7 +477,7 @@ strengths and trade-offs:
   - A web-based platform that provides multi-host orchestration and remote pseudo-terminal (PTY) access to AI agent sessions with live OpenTelemetry metrics. Supports optional git worktree isolation for running multiple agents on the same repository, real-time cost tracking, and companion session chaining.
   - **Ideal for:** Remote, web-based interaction with isolated AI agent sessions across multiple host machines via full PTY emulation.
   - **Not ideal for:** Users who prefer to work exclusively within a local, native terminal multiplexer.
-  - **Restrictions:** Only supports Claude Code, Pi, Antigravity, and Bash sessions. Does not orchestrate GUI-based agents, arbitrary scripts, or non-interactive processes.
+  - **Restrictions:** Only supports Claude Code, Pi, Antigravity, OpenCode, and Bash sessions. Does not orchestrate GUI-based agents, arbitrary scripts, or non-interactive processes.
 
 - **[Agent Commander](https://github.com/cvsloane/agent-commander)**
   - A mission-control dashboard and tmux-first manager for AI agent sessions across multiple hosts. Built with Next.js, Fastify, and a Go-based agent daemon. Features approval queues for agent governance, scoped memory systems, and scheduling with runtime reuse.

--- a/agent/README.md
+++ b/agent/README.md
@@ -10,7 +10,7 @@ The Host Daemon runs on remote development machines and manages AI agent session
 
 The daemon uses YAML/JSON profile files to define how each
 agent tool is spawned, detected, and monitored. Bundled
-profiles for Claude, Pi, Antigravity, and Bash are in
+profiles for Claude, Pi, Antigravity, OpenCode, and Bash are in
 `agent/profiles/`.
 Custom profiles can be added by dropping a YAML file into the
 same directory. See [Agent Profiles](../docs/agent-profiles.md)
@@ -25,6 +25,7 @@ The container image bundles the following tools so spawned agents have everythin
 | **Claude Code** (`@anthropic-ai/claude-code`) | Anthropic Claude AI coding agent |
 | **Pi** (`@earendil-works/pi-coding-agent`) | Pi coding agent — provider-agnostic |
 | **Antigravity CLI** (`agy`) | Google Antigravity AI coding agent |
+| **OpenCode** (`opencode-ai`) | Open-source multi-provider AI coding agent |
 | **Google Cloud CLI** (`gcloud`) | GCP authentication for Claude Code via Vertex AI |
 | **GitHub CLI** (`gh`) | GitHub interaction (PRs, issues, etc.) |
 | **GitLab CLI** (`glab`) | GitLab interaction (MRs, issues, etc.) |

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -8,13 +8,14 @@ startup.
 
 ## Bundled Profiles
 
-Four profiles are included out of the box:
+Five profiles are included out of the box:
 
 | Profile | File | Description |
 |---------|------|-------------|
 | Claude | `agent/profiles/claude.yaml` | Claude Code CLI with OTLP telemetry and MCP detection |
 | Antigravity | `agent/profiles/agy.yaml` | Antigravity CLI (`agy`) — Google's replacement for Gemini CLI |
 | Pi | `agent/profiles/pi.yaml` | Pi coding agent — provider-agnostic, supports Claude/GPT/Gemini/local models |
+| OpenCode | `agent/profiles/opencode.yaml` | OpenCode — open-source multi-provider agent (partial OTLP, see below) |
 | Bash | `agent/profiles/bash.yaml` | Bash shell with PROMPT_COMMAND sidecar telemetry |
 | Gemini | `agent/profiles/archive/gemini.yaml` | Gemini CLI — **retired** from default install (see below) |
 
@@ -471,6 +472,47 @@ it falls back to starting a new conversation. The
 `--conversation <id>` flag is also available for
 resuming a specific conversation, but the profile
 defaults to the simpler `--continue` behavior.
+
+## OpenCode
+
+[OpenCode](https://github.com/anomalyco/opencode) is an
+open-source, multi-provider AI coding agent (TypeScript,
+npm package `opencode-ai`). It supports Anthropic, OpenAI,
+Gemini, GitHub Copilot, AWS Bedrock, and many other
+providers.
+
+### Telemetry
+
+OpenCode has partial OTLP support — traces and logs are
+exported when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, but
+**no metrics** (token usage, cost, activity counters) are
+exported. Dashboard cards show model name and current
+activity from span attributes but no token/cost data.
+
+> **Note:** `OTEL_SERVICE_NAME` is currently ignored by
+> OpenCode — it hardcodes `service.name` to `"opencode"`.
+> Multi-instance tracking relies on the daemon's fallback
+> agent ID resolution. Multiple simultaneous OpenCode
+> sessions may have telemetry routing issues. Tracked
+> upstream at
+> [anomalyco/opencode#25839](https://github.com/anomalyco/opencode/issues/25839).
+
+The profile enables `experimental.openTelemetry` in
+OpenCode's config via `spawn_settings` for richer trace
+data from the Vercel AI SDK integration.
+
+### Session resume
+
+The resume command uses `--continue` to pick up the
+most recent session. If no prior session exists, it
+falls back to starting a new session.
+
+### Configuration
+
+OpenCode stores config in `~/.opencode/config.json`
+(global) and `.opencode/config.json` (project-level).
+MCP servers are configured under the `mcp` key in
+these files.
 
 ## Recommended Pi Extensions
 

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -63,7 +63,7 @@ podman run -d --name host-daemon --network=host \
 > **Missing config directories:** Volume mounts will fail
 > if the directories don't exist on the host. If you
 > haven't used these tools locally, create them first:
-> `mkdir -p ~/.claude ~/.gemini ~/.pi/agent`
+> `mkdir -p ~/.claude ~/.gemini ~/.pi/agent ~/.opencode`
 
 > [!TIP]
 > **Reconfiguring the daemon:** Environment variables and
@@ -103,6 +103,7 @@ podman run -d --name host-daemon --network=host \
 | `~/.claude/` | `/root/.claude` | rw | Claude Code settings |
 | `~/.claude.json` | `/root/.claude.json` | ro | Claude Code MCP server config |
 | `~/.pi/` | `/root/.pi` | rw | Pi coding agent settings and extensions |
+| `~/.opencode/` | `/root/.opencode` | rw | OpenCode settings and config |
 | `~/.config/gcloud` | `/root/.config/gcloud` | ro | GCP credentials (Vertex AI) |
 | `~/.config/gh` | `/root/.config/gh` | ro | GitHub CLI config |
 | `~/.config/glab-cli` | `/root/.config/glab-cli` | ro | GitLab CLI config |
@@ -241,6 +242,7 @@ The daemon container bundles the following tools:
 | **Claude Code** (`@anthropic-ai/claude-code`) | Anthropic Claude AI coding agent |
 | **Pi** (`@earendil-works/pi-coding-agent`) | Pi coding agent — provider-agnostic |
 | **Antigravity CLI** (`agy`) | Google Antigravity AI coding agent |
+| **OpenCode** (`opencode-ai`) | Open-source multi-provider AI coding agent |
 | **Google Cloud CLI** (`gcloud`) | GCP authentication for Claude via Vertex AI |
 | **GitHub CLI** (`gh`) | GitHub interaction (PRs, issues, etc.) |
 | **GitLab CLI** (`glab`) | GitLab interaction (MRs, issues, etc.) |


### PR DESCRIPTION
Adds OpenCode documentation across the project to match the profile added in PR #124.

- Bundled profiles table and dedicated OpenCode section in agent-profiles.md (telemetry limitations, session resume, configuration)
- Agent lists updated in README.md, agent/README.md, host-daemon.md
- Volume mount (`~/.opencode`) added to podman run examples and mkdir hints
- Included tools tables updated