### PR TITLE
feat: add OpenAI Codex CLI agent profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Agent Dashboard</h1>
 
 <p align="center">
-A multi-host orchestration platform for AI coding agents — spawn, monitor, and interact with Claude Code, Pi, Antigravity, OpenCode, and Bash sessions across multiple machines from a single web dashboard.
+A multi-host orchestration platform for AI coding agents — spawn, monitor, and interact with Claude Code, Pi, Antigravity, OpenCode, Codex, and Bash sessions across multiple machines from a single web dashboard.
 </p>
 
 <p align="center">
@@ -28,8 +28,8 @@ AI coding agents. It remotely spawns, monitors, and provides
 interactive terminal access to AI coding agent sessions
 running across multiple development machines — all from a
 single web interface. Supports Claude Code, Pi, Antigravity
-(agy), OpenCode, and Bash out of the box, with new agents
-added via YAML profiles.
+(agy), OpenCode, Codex, and Bash out of the box, with new
+agents added via YAML profiles.
 
 > [!TIP]
 > **How it works:** Install the hub (backend + frontend) on any
@@ -254,6 +254,7 @@ podman run -d --name host-daemon --network=host \
   -v $HOME/.gemini/:/root/.gemini \
   -v $HOME/.pi:/root/.pi \
   -v $HOME/.opencode:/root/.opencode \
+  -v $HOME/.codex:/root/.codex \
   localhost/agent-dashboard-daemon:latest
 ```
 
@@ -262,7 +263,7 @@ podman run -d --name host-daemon --network=host \
 > expect agent config directories to exist on the host.
 > If you haven't used these tools locally, create them first:
 > ```bash
-> mkdir -p ~/.claude ~/.gemini ~/.pi/agent ~/.opencode
+> mkdir -p ~/.claude ~/.gemini ~/.pi/agent ~/.opencode ~/.codex
 > ```
 
 > [!TIP]
@@ -285,7 +286,7 @@ podman run -d --name host-daemon --network=host \
 1. Open `http://your-server-ip:8080`
 2. Your registered hosts appear on the dashboard
 3. Click **Spawn Claude**, **Spawn Pi**, **Spawn Antigravity**,
-   **Spawn OpenCode**, or **Spawn Bash**
+   **Spawn OpenCode**, **Spawn Codex**, or **Spawn Bash**
 4. Select a project directory from the dropdown
 5. Click a running session to attach in a terminal popup
 6. Delete retired hosts via the trash icon
@@ -477,7 +478,7 @@ strengths and trade-offs:
   - A web-based platform that provides multi-host orchestration and remote pseudo-terminal (PTY) access to AI agent sessions with live OpenTelemetry metrics. Supports optional git worktree isolation for running multiple agents on the same repository, real-time cost tracking, and companion session chaining.
   - **Ideal for:** Remote, web-based interaction with isolated AI agent sessions across multiple host machines via full PTY emulation.
   - **Not ideal for:** Users who prefer to work exclusively within a local, native terminal multiplexer.
-  - **Restrictions:** Only supports Claude Code, Pi, Antigravity, OpenCode, and Bash sessions. Does not orchestrate GUI-based agents, arbitrary scripts, or non-interactive processes.
+  - **Restrictions:** Only supports Claude Code, Pi, Antigravity, OpenCode, Codex, and Bash sessions. Does not orchestrate GUI-based agents, arbitrary scripts, or non-interactive processes.
 
 - **[Agent Commander](https://github.com/cvsloane/agent-commander)**
   - A mission-control dashboard and tmux-first manager for AI agent sessions across multiple hosts. Built with Next.js, Fastify, and a Go-based agent daemon. Features approval queues for agent governance, scoped memory systems, and scheduling with runtime reuse.

--- a/agent/README.md
+++ b/agent/README.md
@@ -10,7 +10,8 @@ The Host Daemon runs on remote development machines and manages AI agent session
 
 The daemon uses YAML/JSON profile files to define how each
 agent tool is spawned, detected, and monitored. Bundled
-profiles for Claude, Pi, Antigravity, OpenCode, and Bash are in
+profiles for Claude, Pi, Antigravity, OpenCode, Codex, and
+Bash are in
 `agent/profiles/`.
 Custom profiles can be added by dropping a YAML file into the
 same directory. See [Agent Profiles](../docs/agent-profiles.md)
@@ -26,6 +27,7 @@ The container image bundles the following tools so spawned agents have everythin
 | **Pi** (`@earendil-works/pi-coding-agent`) | Pi coding agent — provider-agnostic |
 | **Antigravity CLI** (`agy`) | Google Antigravity AI coding agent |
 | **OpenCode** (`opencode-ai`) | Open-source multi-provider AI coding agent |
+| **Codex CLI** (`@openai/codex`) | OpenAI Codex terminal coding agent |
 | **Google Cloud CLI** (`gcloud`) | GCP authentication for Claude Code via Vertex AI |
 | **GitHub CLI** (`gh`) | GitHub interaction (PRs, issues, etc.) |
 | **GitLab CLI** (`glab`) | GitLab interaction (MRs, issues, etc.) |

--- a/agent/host_daemon.py
+++ b/agent/host_daemon.py
@@ -1515,6 +1515,8 @@ class HostDaemon:
             tool_hint = "pi"
         elif "opencode" in svc.lower() or "opencode" in all_vals:
             tool_hint = "opencode"
+        elif "codex" in svc.lower() or "codex" in all_vals:
+            tool_hint = "codex"
 
         if tool_hint:
             # Build candidate list.  When the hint is

--- a/agent/profiles/codex.yaml
+++ b/agent/profiles/codex.yaml
@@ -1,0 +1,88 @@
+# OpenAI Codex CLI agent profile
+# Open-source terminal coding agent by OpenAI.
+# Rust binary with TUI, distributed as @openai/codex
+# npm package or via installer script.
+#
+# OTLP telemetry: Supported but configured via
+# config.toml, NOT standard OTEL_* env vars. The
+# daemon patches ~/.codex/config.toml at spawn time
+# via spawn_settings to route traces and logs to the
+# local OTLP receiver. Metrics are available but
+# default to OpenAI's internal Statsig endpoint.
+name: codex
+display_name: Codex
+color: green
+binary: codex
+
+commands:
+  new: ["codex"]
+  resume: ["bash", "-c", "codex resume --last || codex"]
+
+# Codex does not read standard OTEL_* env vars for
+# endpoint configuration. Telemetry is configured
+# entirely via config.toml [otel] section, which
+# spawn_settings patches below.
+env: {}
+
+# No auth gate — Codex supports OpenAI API key,
+# ChatGPT OAuth, and local providers (Ollama,
+# LM Studio). Binary presence is sufficient.
+
+# Spawn-time settings — patch config.toml to route
+# OTLP traces and logs to the daemon's receiver.
+# The {otlp_port} placeholder is expanded by the
+# daemon at spawn time.
+#
+# Note: spawn_settings currently supports JSON files
+# only. Codex uses TOML config. Until TOML support
+# is added to spawn_settings, telemetry must be
+# configured manually in ~/.codex/config.toml:
+#
+#   [otel.exporter]
+#   type = "otlp-http"
+#   endpoint = "http://127.0.0.1:4318/v1/logs"
+#   protocol = "json"
+#
+#   [otel.trace_exporter]
+#   type = "otlp-http"
+#   endpoint = "http://127.0.0.1:4318/v1/traces"
+#   protocol = "json"
+
+mcp:
+  user_files:
+    - ~/.codex/config.toml
+
+# No telemetry metrics section — while Codex supports
+# OTLP metrics, they default to OpenAI's Statsig
+# endpoint. Redirecting to the local receiver requires
+# config.toml patching (TOML, not JSON).
+# Model and activity data may be available from trace
+# span attributes once OTLP is configured.
+
+permission_patterns:
+  - "approve"
+  - "Allow"
+  - "deny"
+
+# Build-time provisioning metadata
+provisioning:
+  install:
+    npm:
+      - "@openai/codex"
+  config_files:
+    - path: "/root/.codex"
+      mkdir: true
+  verify: "codex --version"
+  mounts:
+    - host: "~/.codex"
+      container: "/root/.codex"
+      mode: rw
+  passthrough_env:
+    - OPENAI_API_KEY
+    - CODEX_API_KEY
+    - CODEX_ACCESS_TOKEN
+    # AWS Bedrock support
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_REGION
+    - AWS_PROFILE

--- a/agent/tests/test_host_daemon.py
+++ b/agent/tests/test_host_daemon.py
@@ -466,6 +466,15 @@ class TestResolveAgentId:
         result = daemon._resolve_agent_id({"service.name": "opencode"})
         assert result == "oc-1"
 
+    def test_codex_fallback_service_name(self, daemon):
+        """Codex CLI telemetry matched via service.name hint."""
+        daemon.agents["cx-1"] = {
+            "tool": "codex",
+            "last_output_time": 1.0,
+        }
+        result = daemon._resolve_agent_id({"service.name": "codex"})
+        assert result == "cx-1"
+
 
 # ── E. get_git_info ──────────────────────────────────────────
 

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -8,7 +8,7 @@ startup.
 
 ## Bundled Profiles
 
-Five profiles are included out of the box:
+Six profiles are included out of the box:
 
 | Profile | File | Description |
 |---------|------|-------------|
@@ -16,6 +16,7 @@ Five profiles are included out of the box:
 | Antigravity | `agent/profiles/agy.yaml` | Antigravity CLI (`agy`) — Google's replacement for Gemini CLI |
 | Pi | `agent/profiles/pi.yaml` | Pi coding agent — provider-agnostic, supports Claude/GPT/Gemini/local models |
 | OpenCode | `agent/profiles/opencode.yaml` | OpenCode — open-source multi-provider agent (partial OTLP, see below) |
+| Codex | `agent/profiles/codex.yaml` | OpenAI Codex CLI — Rust-based agent (OTLP via config.toml, see below) |
 | Bash | `agent/profiles/bash.yaml` | Bash shell with PROMPT_COMMAND sidecar telemetry |
 | Gemini | `agent/profiles/archive/gemini.yaml` | Gemini CLI — **retired** from default install (see below) |
 
@@ -513,6 +514,53 @@ OpenCode stores config in `~/.opencode/config.json`
 (global) and `.opencode/config.json` (project-level).
 MCP servers are configured under the `mcp` key in
 these files.
+
+## Codex CLI
+
+[Codex CLI](https://github.com/openai/codex) is OpenAI's
+open-source terminal coding agent, written in Rust and
+distributed as `@openai/codex` via npm.
+
+### Telemetry
+
+Codex has full OTLP support (traces, logs, metrics) but
+configuration is via `~/.codex/config.toml`, **not**
+standard `OTEL_*` environment variables. To route
+telemetry to the dashboard's OTLP receiver, add to
+`~/.codex/config.toml`:
+
+```toml
+[otel.exporter]
+type = "otlp-http"
+endpoint = "http://127.0.0.1:4318/v1/logs"
+protocol = "json"
+
+[otel.trace_exporter]
+type = "otlp-http"
+endpoint = "http://127.0.0.1:4318/v1/traces"
+protocol = "json"
+```
+
+> **Note:** The `spawn_settings` mechanism currently only
+> supports JSON files. Automated TOML patching for Codex
+> telemetry is not yet implemented — configure manually.
+
+### Session resume
+
+The resume command uses `codex resume --last` to pick up
+the most recent session. Specific sessions can be resumed
+by ID: `codex resume <session-id>`.
+
+### Sandbox and permissions
+
+Codex runs tools in a sandbox by default. Sandbox modes:
+- `read-only` — no writes outside sandbox
+- `workspace-write` — write within workspace only
+- `danger-full-access` — no restrictions
+
+For fully automated use in the dashboard, consider
+`--dangerously-bypass-approvals-and-sandbox` (alias
+`--yolo`) if the container provides external sandboxing.
 
 ## Recommended Pi Extensions
 

--- a/docs/host-daemon.md
+++ b/docs/host-daemon.md
@@ -63,7 +63,7 @@ podman run -d --name host-daemon --network=host \
 > **Missing config directories:** Volume mounts will fail
 > if the directories don't exist on the host. If you
 > haven't used these tools locally, create them first:
-> `mkdir -p ~/.claude ~/.gemini ~/.pi/agent ~/.opencode`
+> `mkdir -p ~/.claude ~/.gemini ~/.pi/agent ~/.opencode ~/.codex`
 
 > [!TIP]
 > **Reconfiguring the daemon:** Environment variables and
@@ -104,6 +104,7 @@ podman run -d --name host-daemon --network=host \
 | `~/.claude.json` | `/root/.claude.json` | ro | Claude Code MCP server config |
 | `~/.pi/` | `/root/.pi` | rw | Pi coding agent settings and extensions |
 | `~/.opencode/` | `/root/.opencode` | rw | OpenCode settings and config |
+| `~/.codex/` | `/root/.codex` | rw | Codex CLI settings and config |
 | `~/.config/gcloud` | `/root/.config/gcloud` | ro | GCP credentials (Vertex AI) |
 | `~/.config/gh` | `/root/.config/gh` | ro | GitHub CLI config |
 | `~/.config/glab-cli` | `/root/.config/glab-cli` | ro | GitLab CLI config |
@@ -243,6 +244,7 @@ The daemon container bundles the following tools:
 | **Pi** (`@earendil-works/pi-coding-agent`) | Pi coding agent — provider-agnostic |
 | **Antigravity CLI** (`agy`) | Google Antigravity AI coding agent |
 | **OpenCode** (`opencode-ai`) | Open-source multi-provider AI coding agent |
+| **Codex CLI** (`@openai/codex`) | OpenAI Codex terminal coding agent |
 | **Google Cloud CLI** (`gcloud`) | GCP authentication for Claude via Vertex AI |
 | **GitHub CLI** (`gh`) | GitHub interaction (PRs, issues, etc.) |
 | **GitLab CLI** (`glab`) | GitLab interaction (MRs, issues, etc.) |


### PR DESCRIPTION
## Summary

Adds [OpenAI Codex CLI](https://github.com/openai/codex) as a supported agent in the dashboard. Codex is a Rust-based terminal coding agent distributed as `@openai/codex` via npm.

## Profile Details

- **Install**: `@openai/codex` npm package
- **Resume**: `codex resume --last`
- **OTLP**: Full support (traces, logs, metrics) but configured via `~/.codex/config.toml` `[otel]` section — does **not** read standard `OTEL_*` env vars
- **MCP**: Full support (client via config.toml, server via `codex mcp-server`)
- **Permissions**: Sandbox + approval system with detection patterns
- **Providers**: OpenAI, AWS Bedrock, Ollama, LM Studio

## Known Limitations

- **TOML config required**: OTLP telemetry must be configured manually in `~/.codex/config.toml`. The `spawn_settings` mechanism only supports JSON files, not TOML. Users need to add the `[otel.exporter]` and `[otel.trace_exporter]` sections manually.
- **Rapid version churn**: Daily releases may change metric names and span attributes.

## Changes

- `agent/profiles/codex.yaml` — new profile
- `agent/host_daemon.py` — Codex fallback in `_resolve_agent_id()`
- `agent/tests/test_host_daemon.py` — 1 new test
- Documentation updated across agent-profiles.md, README.md, agent/README.md, host-daemon.md

## Testing

96 unit tests passing.