### PR TITLE
perf: leading-edge debounce for terminal resize (#110)

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -261,16 +261,17 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
     });
 
     // --- Resize handling ---
-    // Debounce fitAddon.fit() to prevent rapid-fire calls
-    // during layout transitions. The fit runs immediately
-    // after the debounce settles — no streaming deferral,
-    // which could block fits indefinitely under high
-    // latency and cause black screens.
+    // Leading-edge debounce for resize: fire immediately
+    // on the first resize event, then suppress further
+    // calls until the trailing edge settles. This ensures
+    // tmux starts redrawing as soon as the user begins
+    // resizing (no 500ms wait), while still coalescing
+    // rapid intermediate events during a window drag.
+    //
     // Track last-sent dimensions to deduplicate resize
-    // events.  When the browser pauses JS during a window
-    // drag, debounce timers freeze and all fire at once on
-    // resume — sending many identical resize events that
-    // each trigger a full tmux redraw.
+    // events. The dedup check in performFit prevents
+    // redundant socket emits even if the debounce fires
+    // multiple times at the same dimensions.
     let lastSentCols = 0;
     let lastSentRows = 0;
 
@@ -300,10 +301,21 @@ const Terminal: React.FC<TerminalProps> = ({ agentId, onClose }) => {
     };
 
     let resizeTimer: ReturnType<typeof setTimeout> | null = null;
-    const RESIZE_DEBOUNCE_MS = 500;
+    let resizeCooldown = false;
+    const RESIZE_DEBOUNCE_MS = 150;
     const debouncedFit = () => {
+      // Leading edge: fire immediately on first event
+      if (!resizeCooldown) {
+        resizeCooldown = true;
+        performFit();
+      }
+      // Trailing edge: reset timer on each event,
+      // fire once after events stop
       if (resizeTimer) clearTimeout(resizeTimer);
-      resizeTimer = setTimeout(performFit, RESIZE_DEBOUNCE_MS);
+      resizeTimer = setTimeout(() => {
+        resizeCooldown = false;
+        performFit();
+      }, RESIZE_DEBOUNCE_MS);
     };
 
     window.addEventListener('resize', debouncedFit);


### PR DESCRIPTION
Addresses the slow terminal resize reported in #110.

**Before:** 500ms trailing-edge debounce. The terminal showed old-size content stretched in new pixel dimensions for the entire window drag + 500ms, then froze while tmux and the agent TUI redrew.

**After:** Leading-edge + trailing-edge at 150ms. The first resize event fires immediately — tmux starts redrawing right away. Subsequent events during the drag are suppressed until they settle for 150ms, then one final resize fires to catch the settled dimensions.

The `lastSentCols`/`lastSentRows` deduplication still prevents redundant socket emits when multiple events resolve to the same terminal dimensions.

Note: The underlying agent TUI redraw cost for long sessions (identified in #110) is unchanged — that's inherent to the agent's SIGWINCH handler complexity. This change reduces the *perceived* delay by eliminating the 500ms wait before the first resize fires.